### PR TITLE
Validate records independently

### DIFF
--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -76,11 +76,18 @@ import itertools
 import json
 import logging
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Annotated, Dict, List, Optional
 from uuid import UUID
 
 import ops
-from pydantic import BaseModel, Field, IPvAnyAddress, ValidationError
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    Field,
+    IPvAnyAddress,
+    ValidationError,
+    ValidationInfo,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -269,6 +276,38 @@ class RequirerEntry(BaseModel):
     record_data: IPvAnyAddress
     uuid: UUID
 
+    def is_valid(self, dns_domains: List[RequirerDomain]) -> bool:
+        """Validate if the entry has a corresponding domain.
+
+        Args:
+            dns_domains: list of provided DNS domains.
+
+        Returns:
+            true: if there is a matching domain for the entry.
+        """
+        domains = [dns_domain.domain for dns_domain in dns_domains]
+        # pylint doesn't recognise self.domain as a str
+        return any(map(self.domain.endswith, domains))  # pylint: disable=no-member
+
+    def validate_dns_entry(self, info: ValidationInfo) -> "RequirerEntry":
+        """Validate DNS entries.
+
+        Args:
+            info: the validation info.
+
+        Returns:
+            the DNS entry if valid.
+
+        Raises:
+            ValueError: if the DNS entry is not valid.
+        """
+        validated_entry = RequirerEntry.model_validate(self)
+        if validated_entry.is_valid(info.data["dns_domains"]):
+            return validated_entry
+        raise ValueError(
+            f"Entry with domain {validated_entry.domain} requested without a valid domain"
+        )
+
 
 class DNSRecordRequirerData(BaseModel):
     """List of domains for the provider to manage.
@@ -279,7 +318,9 @@ class DNSRecordRequirerData(BaseModel):
     """
 
     dns_domains: List[RequirerDomain] = Field(min_length=1)
-    dns_entries: List[RequirerEntry] = Field(min_length=1)
+    dns_entries: List[
+        Annotated[RequirerEntry, AfterValidator(RequirerEntry.validate_dns_entry)]
+    ] = Field(min_length=1)
 
     def to_relation_data(self) -> Dict[str, str]:
         """Convert an instance of DNSRecordRequirerData to the relation representation.
@@ -527,35 +568,6 @@ class DNSRecordProvides(ops.Object):
         relation_data = relation.data[relation.app]
         return DNSRecordRequirerData.from_relation_data(relation_data)
 
-    def _is_requirer_entry_valid(
-        self, entry: RequirerEntry, dns_domains: List[RequirerDomain]
-    ) -> bool:
-        """Validate if an entry has a corresponding domain.
-
-        Args:
-            entry: the DNS entry.
-            dns_domains: list of provided DNS domains.
-
-        Returns:
-            true: if there is a matching domain for the entry.
-        """
-        domains = [dns_domain.domain for dns_domain in dns_domains]
-        return any(map(entry.domain.endswith, domains))
-
-    def _is_dns_requirer_data_valid(self, requirer_data: DNSRecordRequirerData) -> bool:
-        """Semantically validate the requirer data.
-
-        Args:
-            requirer_data: the requirer data.
-
-        Returns:
-            true: if the data is valid.
-        """
-        for entry in requirer_data.dns_entries:
-            if not self._is_requirer_entry_valid(entry, requirer_data.dns_domains):
-                return False
-        return True
-
     def _is_remote_relation_data_valid(self, relation: ops.Relation) -> bool:
         """Validate the relation data.
 
@@ -566,8 +578,8 @@ class DNSRecordProvides(ops.Object):
             true: if the relation data is valid.
         """
         try:
-            requirer_data = self._get_remote_relation_data(relation)
-            return self._is_dns_requirer_data_valid(requirer_data)
+            _ = self._get_remote_relation_data(relation)
+            return True
         except ValidationError as ex:
             error_fields = set(
                 itertools.chain.from_iterable(error["loc"] for error in ex.errors())


### PR DESCRIPTION
Applicable spec: <link> N/A

### Overview

<!-- A high level overview of the change -->
Validate each record instance independently, to allow more granular processing

### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
dns_record.py

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
