### PR TITLE
Fix lib id

### DIFF
--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -60,7 +60,7 @@ class DNSRecordProviderCharm(ops.CharmBase):
 """
 
 # The unique Charmhub library identifier, never change it
-LIBID = "09583c2f9c1d4c0f9a40244cfc20b0c2"
+LIBID = "908bcd1f0ad14cabbc9dca25fa0fc87c"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0


### PR DESCRIPTION
Applicable spec: <link> N/A

### Overview

<!-- A high level overview of the change -->
FIX the library ID

### Rationale

<!-- The reason the change is needed -->
The lib ID is wrong and not unique

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
dns_record.py

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
