### PR TITLE
Basic validation of the entries through the lib

### DIFF
--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -353,14 +353,14 @@ class DNSRecordRequirerData(BaseModel):
     def from_relation(
         cls, model: ops.Model, relation: ops.Relation
     ) -> Tuple["DNSRecordRequirerData", "DNSRecordProviderData"]:
-        """Initialize a new instance of the DNSRecordRequirerData class from the relation data.
+        """Get a Tuple of DNSRecordRequirerData and DNSRecordProviderData from the relation data.
 
         Args:
             model: the Juju model.
             relation: the relation.
 
         Returns:
-            the DNSRecordRequirerData instance.
+            the relation data and the processed entries for it.
 
         Raises:
             ValueError: if the value is not parseable.

--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -284,7 +284,7 @@ class DNSRecordRequirerData(BaseModel):
     service_account_secret_id: str
     dns_entries: List[
         Annotated[RequirerEntry, PlainValidator(RequirerEntry.validate_dns_entry)]
-    ] = Field(min_length=1)
+    ]
 
     def set_service_account_secret_id(self, model: ops.Model, relation: ops.Relation) -> None:
         """Store the service account as a Juju secret.
@@ -311,7 +311,7 @@ class DNSRecordRequirerData(BaseModel):
 
     @classmethod
     def get_service_account(
-        cls, model: ops.Model, service_account_secret_id: str
+        cls, model: ops.Model, service_account_secret_id: Optional[str]
     ) -> Optional[SecretStr]:
         """Retrieve the password corresponding to the password_id.
 

--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -383,20 +383,20 @@ class DNSRecordRequirerData(BaseModel):
             invalid_entries = []
             for dns_entry in dns_entries:
                 try:
-                    if service_account is not None:
-                        validated_entry = RequirerEntry.model_validate(dns_entry)
-                        valid_entries.append(validated_entry)
-                    else:
-                        provider_data = DNSProviderData(
-                            uuid=dns_entry["uuid"],
-                            status=Status.INVALID_CREDENTIALS,
-                            description="Invalid credentials",
-                        )
-                        invalid_entries.append(provider_data)
-                except ValidationError as ex:
                     if "uuid" not in dns_entry:
                         logger.warning("Received DNS entry without an UUID")
                         continue
+                    if service_account is None:
+                        provider_data = DNSProviderData(
+                            uuid=dns_entry["uuid"],
+                            status=Status.INVALID_CREDENTIALS,
+                            description="Missing credentials",
+                        )
+                        invalid_entries.append(provider_data)
+                    else:
+                        validated_entry = RequirerEntry.model_validate(dns_entry)
+                        valid_entries.append(validated_entry)
+                except ValidationError as ex:
                     provider_data = DNSProviderData(
                         uuid=dns_entry["uuid"],
                         status=Status.INVALID_DATA,

--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -282,9 +282,7 @@ class DNSRecordRequirerData(BaseModel):
 
     service_account: Optional[SecretStr] = Field(default=None, exclude=True)
     service_account_secret_id: str
-    dns_entries: List[
-        Annotated[RequirerEntry, PlainValidator(RequirerEntry.validate_dns_entry)]
-    ]
+    dns_entries: List[Annotated[RequirerEntry, PlainValidator(RequirerEntry.validate_dns_entry)]]
 
     def set_service_account_secret_id(self, model: ops.Model, relation: ops.Relation) -> None:
         """Store the service account as a Juju secret.
@@ -447,7 +445,7 @@ class DNSRecordRequestReceived(ops.RelationEvent):
         dns_record_requirer_relation_data: the DNS requirer relation data.
         service_account: service account.
         dns_entries: list of requested entries.
-        procesed_entries: list of processed entries from the original request.
+        processed_entries: list of processed entries from the original request.
     """
 
     @property
@@ -468,7 +466,7 @@ class DNSRecordRequestReceived(ops.RelationEvent):
         return self.dns_record_requirer_relation_data[0].dns_entries
 
     @property
-    def procesed_entries(self) -> List[DNSProviderData]:
+    def processed_entries(self) -> List[DNSProviderData]:
         """Fetch the processed DNS entries."""
         return self.dns_record_requirer_relation_data[1].dns_entries
 
@@ -640,7 +638,7 @@ class DNSRecordProvides(ops.Object):
             _ = self._get_remote_relation_data(self.model, relation)
             return True
         except ValueError as ex:
-            logger.warning("Error validation the relation data %s", ex)
+            logger.warning("Error validating the relation data %s", ex)
             return False
 
     def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:

--- a/tests/unit/test_library_dns_record.py
+++ b/tests/unit/test_library_dns_record.py
@@ -8,7 +8,6 @@ import uuid
 from typing import Dict, List
 
 import ops
-import pytest
 from charms.bind.v0 import dns_record
 from ops.testing import Harness
 from pydantic import IPvAnyAddress
@@ -482,8 +481,21 @@ def test_dns_record_requirer_get_remote_relation_data_throws_exception_when_secr
         "dns-record", "dns-record", app_data=get_requirer_relation_data(secret.id)
     )
 
-    with pytest.raises(ValueError):
-        harness.charm.dns_record.get_remote_relation_data()
+    requirer_data, provider_data = harness.charm.dns_record.get_remote_relation_data()
+    assert not requirer_data.service_account
+    assert len(requirer_data.dns_entries) == 0
+    assert len(provider_data.dns_entries) == 2
+    passed_data = get_dns_record_requirer_data(secret.id)
+    assert provider_data.dns_entries[0].uuid == (
+        passed_data.dns_entries[0].uuid  # pylint: disable=unsubscriptable-object
+    )
+    assert provider_data.dns_entries[0].status == dns_record.Status.INVALID_CREDENTIALS
+    assert provider_data.dns_entries[0].description
+    assert provider_data.dns_entries[1].uuid == (
+        passed_data.dns_entries[1].uuid  # pylint: disable=unsubscriptable-object
+    )
+    assert provider_data.dns_entries[1].status == dns_record.Status.INVALID_CREDENTIALS
+    assert provider_data.dns_entries[1].description
 
 
 def test_dns_record_requirer_get_remote_relation_data_throws_exception_when_secret_doesnt_exist():
@@ -500,8 +512,21 @@ def test_dns_record_requirer_get_remote_relation_data_throws_exception_when_secr
         "dns-record", "dns-record", app_data=get_requirer_relation_data("unexisting")
     )
 
-    with pytest.raises(ValueError):
-        harness.charm.dns_record.get_remote_relation_data()
+    requirer_data, provider_data = harness.charm.dns_record.get_remote_relation_data()
+    assert not requirer_data.service_account
+    assert len(requirer_data.dns_entries) == 0
+    assert len(provider_data.dns_entries) == 2
+    passed_data = get_dns_record_requirer_data("")
+    assert provider_data.dns_entries[0].uuid == (
+        passed_data.dns_entries[0].uuid  # pylint: disable=unsubscriptable-object
+    )
+    assert provider_data.dns_entries[0].status == dns_record.Status.INVALID_CREDENTIALS
+    assert provider_data.dns_entries[0].description
+    assert provider_data.dns_entries[1].uuid == (
+        passed_data.dns_entries[1].uuid  # pylint: disable=unsubscriptable-object
+    )
+    assert provider_data.dns_entries[1].status == dns_record.Status.INVALID_CREDENTIALS
+    assert provider_data.dns_entries[1].description
 
 
 def test_dns_record_provider_get_remote_relation_data():

--- a/tests/unit/test_library_dns_record.py
+++ b/tests/unit/test_library_dns_record.py
@@ -356,7 +356,7 @@ def test_dns_record_provider_emmits_event():
     assert len(events) == 1
     assert events[0].service_account == get_dns_record_requirer_data(secret).service_account
     assert events[0].dns_entries == get_dns_record_requirer_data(secret).dns_entries
-    assert events[0].procesed_entries == []
+    assert events[0].processed_entries == []
 
 
 def test_dns_record_provider_emmits_event_when_partially_valid():
@@ -382,12 +382,12 @@ def test_dns_record_provider_emmits_event_when_partially_valid():
     assert events[0].dns_entries[0] == (
         requirer_data.dns_entries[1]  # pylint: disable=unsubscriptable-object
     )
-    assert len(events[0].procesed_entries) == 1
-    assert events[0].procesed_entries[0].uuid == (
+    assert len(events[0].processed_entries) == 1
+    assert events[0].processed_entries[0].uuid == (
         requirer_data.dns_entries[0].uuid  # pylint: disable=unsubscriptable-object
     )
-    assert events[0].procesed_entries[0].status == dns_record.Status.INVALID_DATA
-    assert events[0].procesed_entries[0].description
+    assert events[0].processed_entries[0].status == dns_record.Status.INVALID_DATA
+    assert events[0].processed_entries[0].description
 
 
 def test_dns_record_provider_emmits_event_when_partially_valid_ignores_no_uuid():
@@ -413,7 +413,7 @@ def test_dns_record_provider_emmits_event_when_partially_valid_ignores_no_uuid()
     assert events[0].dns_entries[0] == (
         requirer_data.dns_entries[1]  # pylint: disable=unsubscriptable-object
     )
-    assert events[0].procesed_entries == []
+    assert events[0].processed_entries == []
 
 
 def test_dns_record_provider_doesnt_emmit_event_when_relation_data_invalid():


### PR DESCRIPTION
Applicable spec: <link>
N/A

### Overview

<!-- A high level overview of the change -->
Basic validation of the entries through the lib. Instead of the requirer data when valid, a tuple with the valid entries and the response for the invalid is returned

### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
dns_record.py

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
