### PR TITLE
Make service_account_secret_id optional

### DIFF
--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -288,8 +288,15 @@ class DNSRecordRequirerData(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_service_account_or_service_account_secret_id(cls, values: Dict) -> Dict:
-        # ignore pflake errors for this function as we're getting a conflicting DCO024 and DCO050
-        """Check if service_account or service_account_secret_id is defined."""  # noqa
+        """Check if service_account or service_account_secret_id is defined.
+
+        Args:
+            values: The values to validate
+        Returns:
+            values: The validated values
+        Raises:
+            When neither service_account nor service_account_secret_id is defined
+        """
         if (values.get("service_account") is None) and (
             values.get("service_account_secret_id") is None
         ):

--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -287,7 +287,8 @@ class DNSRecordRequirerData(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def check_service_account_or_service_account_secret_id(cls, values: Dict) -> Dict:
+    # ignore pflake errors for this function: https://github.com/canonical/bind-operator/actions/runs/8914628790/job/24482601814?pr=16#step:6:15
+    def check_service_account_or_service_account_secret_id(cls, values: Dict) -> Dict:  # noqa
         """Check if service_account or service_account_secret_id is defined.
 
         Args:

--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -287,17 +287,9 @@ class DNSRecordRequirerData(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    # ignore pflake errors for this function: https://github.com/canonical/bind-operator/actions/runs/8914628790/job/24482601814?pr=16#step:6:15
-    def check_service_account_or_service_account_secret_id(cls, values: Dict) -> Dict:  # noqa
-        """Check if service_account or service_account_secret_id is defined.
-
-        Args:
-            values: input values defining the instance on creation
-        Raises:
-            ValueError: when either service_account or service_accounrt_secret_id is not defined
-        Returns:
-            values: input values defining the instance on creation
-        """
+    def check_service_account_or_service_account_secret_id(cls, values: Dict) -> Dict:
+        # ignore pflake errors for this function as we're getting a conflicting DCO024 and DCO050
+        """Check if service_account or service_account_secret_id is defined."""  # noqa
         if (values.get("service_account") is None) and (
             values.get("service_account_secret_id") is None
         ):

--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -297,7 +297,7 @@ class DNSRecordRequirerData(BaseModel):
             values: The validated values
 
         Raises:
-            When neither service_account nor service_account_secret_id is defined
+            ValueError: When neither service_account nor service_account_secret_id is defined
         """
         if (values.get("service_account") is None) and (
             values.get("service_account_secret_id") is None

--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -67,7 +67,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic>=2"]
 
@@ -281,7 +281,7 @@ class DNSRecordRequirerData(BaseModel):
     """
 
     service_account: Optional[SecretStr] = Field(default=None, exclude=True)
-    service_account_secret_id: str
+    service_account_secret_id: Optional[str]
     dns_entries: List[Annotated[RequirerEntry, PlainValidator(RequirerEntry.validate_dns_entry)]]
 
     def set_service_account_secret_id(self, model: ops.Model, relation: ops.Relation) -> None:

--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -80,7 +80,6 @@ from uuid import UUID
 
 import ops
 from pydantic import (
-    model_validator,
     BaseModel,
     Field,
     IPvAnyAddress,
@@ -88,6 +87,7 @@ from pydantic import (
     SecretStr,
     ValidationError,
     ValidationInfo,
+    model_validator,
 )
 
 logger = logging.getLogger(__name__)
@@ -282,15 +282,25 @@ class DNSRecordRequirerData(BaseModel):
     """
 
     service_account: Optional[SecretStr] = Field(default=None, exclude=True)
-    service_account_secret_id: Optional[str]= Field(default=None)
+    service_account_secret_id: Optional[str] = Field(default=None)
     dns_entries: List[Annotated[RequirerEntry, PlainValidator(RequirerEntry.validate_dns_entry)]]
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
     def check_service_account_or_service_account_secret_id(cls, values: Dict) -> Dict:
-        """Check if service_account or service_account_secret_id is defined."""
-        if (values.get('service_account') is None) and (values.get("service_account_secret_id") is None):
-            raise ValueError('either service_account or service_account_secret_id is required')
+        """Check if service_account or service_account_secret_id is defined.
+
+        Args:
+            values: input values defining the instance on creation
+        Raises:
+            ValueError: when either service_account or service_accounrt_secret_id is not defined
+        Returns:
+            values: input values defining the instance on creation
+        """
+        if (values.get("service_account") is None) and (
+            values.get("service_account_secret_id") is None
+        ):
+            raise ValueError("either service_account or service_account_secret_id is required")
         return values
 
     def set_service_account_secret_id(self, model: ops.Model, relation: ops.Relation) -> None:

--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -281,7 +281,7 @@ class DNSRecordRequirerData(BaseModel):
     """
 
     service_account: Optional[SecretStr] = Field(default=None, exclude=True)
-    service_account_secret_id: Optional[str]
+    service_account_secret_id: Optional[str]= Field(default=None)
     dns_entries: List[Annotated[RequirerEntry, PlainValidator(RequirerEntry.validate_dns_entry)]]
 
     def set_service_account_secret_id(self, model: ops.Model, relation: ops.Relation) -> None:

--- a/lib/charms/bind/v0/dns_record.py
+++ b/lib/charms/bind/v0/dns_record.py
@@ -292,8 +292,10 @@ class DNSRecordRequirerData(BaseModel):
 
         Args:
             values: The values to validate
+
         Returns:
             values: The validated values
+
         Raises:
             When neither service_account nor service_account_secret_id is defined
         """

--- a/tests/unit/test_library_dns_record.py
+++ b/tests/unit/test_library_dns_record.py
@@ -273,7 +273,7 @@ def test_dns_record_requirer_update_relation_data():
     assert relation.data[harness.model.app] == get_requirer_relation_data(secret)
 
 
-def test_dns_record_requirer_emmits_event():
+def test_dns_record_requirer_emits_event():
     """
     arrange: given a requirer charm.
     act: update the remote relation databag with valid values.
@@ -290,7 +290,7 @@ def test_dns_record_requirer_emmits_event():
     assert events[0].dns_entries == DNS_RECORD_PROVIDER_DATA.dns_entries
 
 
-def test_dns_record_requirer_doesnt_emmit_event_when_relation_data_invalid():
+def test_dns_record_requirer_doesnt_emit_event_when_relation_data_invalid():
     """
     arrange: given a requirer charm.
     act: update the remote relation databag with invalid values.
@@ -305,7 +305,7 @@ def test_dns_record_requirer_doesnt_emmit_event_when_relation_data_invalid():
     assert len(harness.charm.events) == 0
 
 
-def test_dns_record_requirer_doesnt_emmit_event_when_relation_data_unparsable():
+def test_dns_record_requirer_doesnt_emit_event_when_relation_data_unparsable():
     """
     arrange: given a requirer charm.
     act: update the remote relation databag with unparsable values.
@@ -338,7 +338,7 @@ def test_dns_record_provider_update_relation_data():
     assert relation.data[harness.model.app] == PROVIDER_RELATION_DATA
 
 
-def test_dns_record_provider_emmits_event():
+def test_dns_record_provider_emits_event():
     """
     arrange: given a provider charm.
     act: update the remote relation databag with valid values.
@@ -358,7 +358,7 @@ def test_dns_record_provider_emmits_event():
     assert events[0].processed_entries == []
 
 
-def test_dns_record_provider_emmits_event_when_partially_valid():
+def test_dns_record_provider_emits_event_when_partially_valid():
     """
     arrange: given a provider charm.
     act: update the remote relation databag with valid values.
@@ -389,7 +389,7 @@ def test_dns_record_provider_emmits_event_when_partially_valid():
     assert events[0].processed_entries[0].description
 
 
-def test_dns_record_provider_emmits_event_when_partially_valid_ignores_no_uuid():
+def test_dns_record_provider_emits_event_when_partially_valid_ignores_no_uuid():
     """
     arrange: given a provider charm.
     act: update the remote relation databag with valid values.
@@ -415,7 +415,7 @@ def test_dns_record_provider_emmits_event_when_partially_valid_ignores_no_uuid()
     assert events[0].processed_entries == []
 
 
-def test_dns_record_provider_doesnt_emmit_event_when_relation_data_invalid():
+def test_dns_record_provider_doesnt_emit_event_when_relation_data_invalid():
     """
     arrange: given a provider charm.
     act: update the remote relation databag with invalid values.
@@ -430,7 +430,7 @@ def test_dns_record_provider_doesnt_emmit_event_when_relation_data_invalid():
     assert len(harness.charm.events) == 0
 
 
-def test_dns_record_provider_doesnt_emmit_event_when_relation_data_unparsable():
+def test_dns_record_provider_doesnt_emit_event_when_relation_data_unparsable():
     """
     arrange: given a provider charm.
     act: update the remote relation databag with unparsable values.

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ description = Check code against coding style standards
 deps =
     black
     codespell
-    flake8<6.0.0
+    flake8
     flake8-builtins
     flake8-copyright<6.0.0
     flake8-docstrings>=1.6.0
@@ -47,7 +47,7 @@ deps =
     pep8-naming
     pydocstyle>=2.10
     pylint
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
Applicable spec: <link>
N/A

### Overview

<!-- A high level overview of the change -->
Make service_account_secret_id optional

### Rationale

<!-- The reason the change is needed -->
The secret ID will not be available in the requirer when the object is first instantiated

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
dns_record.py

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
