### PR TITLE
Add helper function to deploy any-charm

### DIFF
--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -39,7 +39,8 @@ class AnyCharm(AnyCharmBase):
             test record data
         """
         # We read the dns entries from a known json file
-        with open("/tmp/dns_entries.json", "r", encoding="utf-8") as dns_entries_file:
+        # It's okay to write to /tmp for these tests, so # nosec is used
+        with open("/tmp/dns_entries.json", "r", encoding="utf-8") as dns_entries_file:  # nosec
             json_entries = json.load(dns_entries_file)
 
             dns_entries = [

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -39,7 +39,7 @@ class AnyCharm(AnyCharmBase):
             test record data
         """
         # We read the dns entries from a known json file
-        with open("dns_entries.json", "r", encoding="utf-8") as dns_entries_file:
+        with open("/tmp/dns_entries.json", "r", encoding="utf-8") as dns_entries_file:
             json_entries = json.load(dns_entries_file)
 
             dns_entries = [

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -5,6 +5,7 @@
 
 """This code should be loaded into any-charm which is used for integration tests."""
 
+import json
 import logging
 import uuid
 
@@ -37,20 +38,28 @@ class AnyCharm(AnyCharmBase):
         Returns:
             test record data
         """
-        dns_entry = RequirerEntry(
-            domain="dns.test",
-            host_label="admin",
-            ttl=600,
-            record_class="IN",
-            record_type="A",
-            record_data="42.42.42.42",
-            uuid=uuid.uuid4(),
-        )
-        dns_record_requirer_data = DNSRecordRequirerData(
-            dns_entries=[dns_entry],
-            service_account="fakeserviceaccount",
-        )
-        return dns_record_requirer_data
+        # We read the dns entries from a known json file
+        with open("dns_entries.json", "r", encoding="utf-8") as dns_entries_file:
+            json_entries = json.load(dns_entries_file)
+
+            dns_entries = [
+                RequirerEntry(
+                    domain=e["domain"],
+                    host_label=e["host_label"],
+                    ttl=e["ttl"],
+                    record_class=e["record_class"],
+                    record_type=e["record_type"],
+                    record_data=e["record_data"],
+                    uuid=uuid.uuid4(),
+                )
+                for e in json_entries
+            ]
+
+            dns_record_requirer_data = DNSRecordRequirerData(
+                dns_entries=dns_entries,
+                service_account="fakeserviceaccount",
+            )
+            return dns_record_requirer_data
 
     def _on_dns_record_relation_joined(self, event: ops.RelationEvent) -> None:
         """Handle dns_record relation joined.

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -42,7 +42,7 @@ class AnyCharm(AnyCharmBase):
         # We read the dns entries from a known json file
         # It's okay to write to /tmp for these tests, so # nosec is used
         json_entries = json.loads(
-            pathlib.Path("/tmp/dns_entries.json").read_text(encoding="utf-8")
+            pathlib.Path("/tmp/dns_entries.json").read_text(encoding="utf-8")  # nosec
         )
 
         dns_entries = [

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -7,6 +7,7 @@
 
 import json
 import logging
+import pathlib
 import uuid
 
 import ops
@@ -40,27 +41,28 @@ class AnyCharm(AnyCharmBase):
         """
         # We read the dns entries from a known json file
         # It's okay to write to /tmp for these tests, so # nosec is used
-        with open("/tmp/dns_entries.json", "r", encoding="utf-8") as dns_entries_file:  # nosec
-            json_entries = json.load(dns_entries_file)
+        json_entries = json.loads(
+            pathlib.Path("/tmp/dns_entries.json").read_text(encoding="utf-8")
+        )
 
-            dns_entries = [
-                RequirerEntry(
-                    domain=e["domain"],
-                    host_label=e["host_label"],
-                    ttl=e["ttl"],
-                    record_class=e["record_class"],
-                    record_type=e["record_type"],
-                    record_data=e["record_data"],
-                    uuid=uuid.uuid4(),
-                )
-                for e in json_entries
-            ]
-
-            dns_record_requirer_data = DNSRecordRequirerData(
-                dns_entries=dns_entries,
-                service_account="fakeserviceaccount",
+        dns_entries = [
+            RequirerEntry(
+                domain=e["domain"],
+                host_label=e["host_label"],
+                ttl=e["ttl"],
+                record_class=e["record_class"],
+                record_type=e["record_type"],
+                record_data=e["record_data"],
+                uuid=uuid.uuid4(),
             )
-            return dns_record_requirer_data
+            for e in json_entries
+        ]
+
+        dns_record_requirer_data = DNSRecordRequirerData(
+            dns_entries=dns_entries,
+            service_account="fakeserviceaccount",
+        )
+        return dns_record_requirer_data
 
     def _on_dns_record_relation_joined(self, event: ops.RelationEvent) -> None:
         """Handle dns_record relation joined.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -175,7 +175,8 @@ async def generate_anycharm_relation(
     any_charm_src_overwrite = {
         "any_charm.py": any_charm_content,
         "dns_record.py": dns_record_content,
-        "/tmp/dns_entries.json": json.dumps(dns_entries),
+        # It's okay to write to /tmp for these tests, so # nosec is used
+        "/tmp/dns_entries.json": json.dumps(dns_entries),  # nosec
     }
 
     # We deploy https://charmhub.io/any-charm and inject the any_charm.py behavior

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -175,7 +175,7 @@ async def generate_anycharm_relation(
     any_charm_src_overwrite = {
         "any_charm.py": any_charm_content,
         "dns_record.py": dns_record_content,
-        "dns_entries.json": json.dumps(dns_entries),
+        "/tmp/dns_entries.json": json.dumps(dns_entries),
     }
 
     # We deploy https://charmhub.io/any-charm and inject the any_charm.py behavior

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,12 +4,35 @@
 
 """Helper functions for the integration tests."""
 
+import json
+import pathlib
 import random
 import string
 import tempfile
+import typing
 
 import ops
 from pytest_operator.plugin import OpsTest
+
+
+class DnsEntry(typing.TypedDict):
+    """Class used to pass DNS entries around in tests.
+
+    Attributes:
+        domain: example: "dns.test"
+        host_label: example: "admin"
+        ttl: example: 600
+        record_class: example: "IN"
+        record_type: example: "A"
+        record_data: example: "42.42.42.42"
+    """
+
+    domain: str
+    host_label: str
+    ttl: int
+    record_class: str
+    record_type: str
+    record_data: str
 
 
 class ExecutionError(Exception):
@@ -127,3 +150,47 @@ async def dispatch_to_unit(
         "--",
         f"export JUJU_DISPATCH_PATH=hooks/{hook_name}; ./dispatch",
     )
+
+
+async def generate_anycharm_relation(
+    app: ops.model.Application,
+    ops_test: OpsTest,
+    any_charm_name: str,
+    dns_entries: typing.List[DnsEntry],
+):
+    """Deploy any-charm with a wanted DNS entries config and relate it to the bind app.
+
+    Args:
+        app: Deployed bind-operator app
+        ops_test: The ops test framework instance
+        any_charm_name: Name of the to be deployed any-charm
+        dns_entries: List of DNS entries for any-charm
+    """
+    any_app_name = any_charm_name
+    any_charm_content = pathlib.Path("tests/integration/any_charm.py").read_text(encoding="utf-8")
+    dns_record_content = pathlib.Path("lib/charms/bind/v0/dns_record.py").read_text(
+        encoding="utf-8"
+    )
+
+    any_charm_src_overwrite = {
+        "any_charm.py": any_charm_content,
+        "dns_record.py": dns_record_content,
+        "dns_entries.json": json.dumps(dns_entries),
+    }
+
+    # We deploy https://charmhub.io/any-charm and inject the any_charm.py behavior
+    # See https://github.com/canonical/any-charm on how to use any-charm
+    assert ops_test.model
+    any_charm = await ops_test.model.deploy(
+        "any-charm",
+        application_name=any_app_name,
+        channel="beta",
+        config={
+            "src-overwrite": json.dumps(any_charm_src_overwrite),
+            "python-packages": "pydantic==2.7.1\n",
+        },
+    )
+    await ops_test.model.wait_for_idle(status="active")
+
+    await ops_test.model.add_relation(f"{any_charm.name}", f"{app.name}")
+    await ops_test.model.wait_for_idle(status="active")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -6,6 +6,7 @@
 
 import logging
 import time
+import typing
 
 import ops
 import pytest
@@ -95,9 +96,32 @@ async def test_basic_dns_config(app: ops.model.Application, ops_test: OpsTest):
     ).strip() == '"this-is-a-test"'
 
 
+@pytest.mark.parametrize(
+    "any_charm_name, relation_data",
+    (
+        (
+            "any-app",
+            [
+                tests.integration.helpers.DnsEntry(
+                    domain="dns.test",
+                    host_label="admin",
+                    ttl=600,
+                    record_class="IN",
+                    record_type="A",
+                    record_data="42.42.42.42",
+                )
+            ],
+        ),
+    ),
+)
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_basic_relation(app: ops.model.Application, ops_test: OpsTest):
+async def test_basic_relation(
+    app: ops.model.Application,
+    ops_test: OpsTest,
+    any_charm_name: str,
+    relation_data: typing.List[tests.integration.helpers.DnsEntry],
+):
     """
     arrange: given deployed app, deploy any-charm that can relate to it
     act: relate any-charm to the deployed app
@@ -106,17 +130,8 @@ async def test_basic_relation(app: ops.model.Application, ops_test: OpsTest):
     await tests.integration.helpers.generate_anycharm_relation(
         app,
         ops_test,
-        "any-app",
-        [
-            tests.integration.helpers.DnsEntry(
-                domain="dns.test",
-                host_label="admin",
-                ttl=600,
-                record_class="IN",
-                record_type="A",
-                record_data="42.42.42.42",
-            )
-        ],
+        any_charm_name,
+        relation_data,
     )
 
     assert (


### PR DESCRIPTION
### Overview

Add helper function to deploy any-charm. This is done as preparatory work to more extended tests for the dns_entry relation with bind-operator.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
