### PR TITLE
Remove unnecessary typing module usage

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -3,7 +3,6 @@
 
 """Common data structures used in this charm."""
 
-import typing
 
 import pydantic
 from charms.bind.v0.dns_record import RecordClass, RecordType, RequirerEntry
@@ -37,7 +36,7 @@ class DnsEntry(pydantic.BaseModel):
         Returns:
             True if they conflict, False otherwise.
         """
-        key_attributes: typing.Set[str] = {"domain", "host_label", "record_class", "record_type"}
+        key_attributes: set[str] = {"domain", "host_label", "record_class", "record_type"}
         return hash(tuple(getattr(self, k) for k in key_attributes)) == hash(
             tuple(getattr(other, k) for k in key_attributes)
         )
@@ -60,7 +59,7 @@ class Zone(pydantic.BaseModel):
     """
 
     domain: str
-    entries: typing.List[DnsEntry]
+    entries: list[DnsEntry]
 
 
 def create_dns_entry_from_requirer_entry(requirer_entry: RequirerEntry) -> DnsEntry:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -9,7 +9,6 @@ import pathlib
 import random
 import string
 import tempfile
-import typing
 
 import ops
 from pytest_operator.plugin import OpsTest
@@ -138,7 +137,7 @@ async def generate_anycharm_relation(
     app: ops.model.Application,
     ops_test: OpsTest,
     any_charm_name: str,
-    dns_entries: typing.List[models.DnsEntry],
+    dns_entries: list[models.DnsEntry],
 ):
     """Deploy any-charm with a wanted DNS entries config and integrate it to the bind app.
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -6,7 +6,6 @@
 
 import logging
 import time
-import typing
 
 import ops
 import pytest
@@ -200,7 +199,7 @@ async def test_dns_record_relation(
     ops_test: OpsTest,
     model: Model,
     status: ops.model.StatusBase,
-    integration_datasets: typing.Tuple[typing.List[models.DnsEntry]],
+    integration_datasets: tuple[list[models.DnsEntry]],
 ):
     """
     arrange: given deployed bind-operator

--- a/tests/unit/test_library_dns_record.py
+++ b/tests/unit/test_library_dns_record.py
@@ -5,7 +5,6 @@
 import json
 import secrets
 import uuid
-from typing import Dict, List
 
 import ops
 from charms.bind.v0 import dns_record
@@ -33,7 +32,7 @@ UUID3 = uuid.uuid4()
 UUID4 = uuid.uuid4()
 
 
-def get_requirer_relation_data(secret_id_password_user: str) -> Dict[str, str]:
+def get_requirer_relation_data(secret_id_password_user: str) -> dict[str, str]:
     """Retrieve the requirer relation data.
 
     Args:
@@ -66,7 +65,7 @@ def get_requirer_relation_data(secret_id_password_user: str) -> Dict[str, str]:
     }
 
 
-def get_requirer_relation_data_partially_invalid(secret_id_password_user: str) -> Dict[str, str]:
+def get_requirer_relation_data_partially_invalid(secret_id_password_user: str) -> dict[str, str]:
     """Retrieve the requirer relation data.
 
     Args:
@@ -98,7 +97,7 @@ def get_requirer_relation_data_partially_invalid(secret_id_password_user: str) -
     }
 
 
-def get_requirer_relation_data_without_uuid(secret_id_password_user: str) -> Dict[str, str]:
+def get_requirer_relation_data_without_uuid(secret_id_password_user: str) -> dict[str, str]:
     """Retrieve the requirer relation data.
 
     Args:
@@ -219,7 +218,7 @@ class DNSRecordRequirerCharm(ops.CharmBase):
         """
         super().__init__(*args)
         self.dns_record = dns_record.DNSRecordRequires(self)
-        self.events: List[dns_record.DNSRecordRequestProcessed] = []
+        self.events: list[dns_record.DNSRecordRequestProcessed] = []
         self.framework.observe(self.dns_record.on.dns_record_request_processed, self._record_event)
 
     def _record_event(self, event: ops.EventBase) -> None:
@@ -242,7 +241,7 @@ class DNSRecordProviderCharm(ops.CharmBase):
         """
         super().__init__(*args)
         self.dns_record = dns_record.DNSRecordProvides(self)
-        self.events: List[dns_record.DNSRecordRequestReceived] = []
+        self.events: list[dns_record.DNSRecordRequestReceived] = []
         self.framework.observe(self.dns_record.on.dns_record_request_received, self._record_event)
 
     def _record_event(self, event: ops.EventBase) -> None:


### PR DESCRIPTION
### Overview

Using the `typing` module is not so necessary anymore since we're at least on python3.10

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
