### PR TITLE
Reload bind timer

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,5 +8,5 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
     with:
-      self-hosted-runner: true
+      self-hosted-runner: false  # Avoid using our quota of github requests for unit tests
       self-hosted-runner-label: "edge"

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -1,0 +1,288 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Abstractions for stopping, starting and managing system services via systemd.
+
+This library assumes that your charm is running on a platform that uses systemd. E.g.,
+Centos 7 or later, Ubuntu Xenial (16.04) or later.
+
+For the most part, we transparently provide an interface to a commonly used selection of
+systemd commands, with a few shortcuts baked in. For example, service_pause and
+service_resume with run the mask/unmask and enable/disable invocations.
+
+Example usage:
+
+```python
+from charms.operator_libs_linux.v0.systemd import service_running, service_reload
+
+# Start a service
+if not service_running("mysql"):
+    success = service_start("mysql")
+
+# Attempt to reload a service, restarting if necessary
+success = service_reload("nginx", restart_on_failure=True)
+```
+"""
+
+__all__ = [  # Don't export `_systemctl`. (It's not the intended way of using this lib.)
+    "SystemdError",
+    "daemon_reload",
+    "service_disable",
+    "service_enable",
+    "service_failed",
+    "service_pause",
+    "service_reload",
+    "service_restart",
+    "service_resume",
+    "service_running",
+    "service_start",
+    "service_stop",
+]
+
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "045b0d179f6b4514a8bb9b48aee9ebaf"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 4
+
+
+class SystemdError(Exception):
+    """Custom exception for SystemD related errors."""
+
+
+def _systemctl(*args: str, check: bool = False) -> int:
+    """Control a system service using systemctl.
+
+    Args:
+        *args: Arguments to pass to systemctl.
+        check: Check the output of the systemctl command. Default: False.
+
+    Returns:
+        Returncode of systemctl command execution.
+
+    Raises:
+        SystemdError: Raised if calling systemctl returns a non-zero returncode and check is True.
+    """
+    cmd = ["systemctl", *args]
+    logger.debug(f"Executing command: {cmd}")
+    try:
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            encoding="utf-8",
+            check=check,
+        )
+        logger.debug(
+            f"Command {cmd} exit code: {proc.returncode}. systemctl output:\n{proc.stdout}"
+        )
+        return proc.returncode
+    except subprocess.CalledProcessError as e:
+        raise SystemdError(
+            f"Command {cmd} failed with returncode {e.returncode}. systemctl output:\n{e.stdout}"
+        )
+
+
+def service_running(service_name: str) -> bool:
+    """Report whether a system service is running.
+
+    Args:
+        service_name: The name of the service to check.
+
+    Return:
+        True if service is running/active; False if not.
+    """
+    # If returncode is 0, this means that is service is active.
+    return _systemctl("--quiet", "is-active", service_name) == 0
+
+
+def service_failed(service_name: str) -> bool:
+    """Report whether a system service has failed.
+
+    Args:
+        service_name: The name of the service to check.
+
+    Returns:
+        True if service is marked as failed; False if not.
+    """
+    # If returncode is 0, this means that the service has failed.
+    return _systemctl("--quiet", "is-failed", service_name) == 0
+
+
+def service_start(*args: str) -> bool:
+    """Start a system service.
+
+    Args:
+        *args: Arguments to pass to `systemctl start` (normally the service name).
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl start ...` returns a non-zero returncode.
+    """
+    return _systemctl("start", *args, check=True) == 0
+
+
+def service_stop(*args: str) -> bool:
+    """Stop a system service.
+
+    Args:
+        *args: Arguments to pass to `systemctl stop` (normally the service name).
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl stop ...` returns a non-zero returncode.
+    """
+    return _systemctl("stop", *args, check=True) == 0
+
+
+def service_restart(*args: str) -> bool:
+    """Restart a system service.
+
+    Args:
+        *args: Arguments to pass to `systemctl restart` (normally the service name).
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl restart ...` returns a non-zero returncode.
+    """
+    return _systemctl("restart", *args, check=True) == 0
+
+
+def service_enable(*args: str) -> bool:
+    """Enable a system service.
+
+    Args:
+        *args: Arguments to pass to `systemctl enable` (normally the service name).
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl enable ...` returns a non-zero returncode.
+    """
+    return _systemctl("enable", *args, check=True) == 0
+
+
+def service_disable(*args: str) -> bool:
+    """Disable a system service.
+
+    Args:
+        *args: Arguments to pass to `systemctl disable` (normally the service name).
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl disable ...` returns a non-zero returncode.
+    """
+    return _systemctl("disable", *args, check=True) == 0
+
+
+def service_reload(service_name: str, restart_on_failure: bool = False) -> bool:
+    """Reload a system service, optionally falling back to restart if reload fails.
+
+    Args:
+        service_name: The name of the service to reload.
+        restart_on_failure:
+            Boolean indicating whether to fall back to a restart if the reload fails.
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl reload|restart ...` returns a non-zero returncode.
+    """
+    try:
+        return _systemctl("reload", service_name, check=True) == 0
+    except SystemdError:
+        if restart_on_failure:
+            return service_restart(service_name)
+        else:
+            raise
+
+
+def service_pause(service_name: str) -> bool:
+    """Pause a system service.
+
+    Stops the service and prevents the service from starting again at boot.
+
+    Args:
+        service_name: The name of the service to pause.
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if service is still running after being paused by systemctl.
+    """
+    _systemctl("disable", "--now", service_name)
+    _systemctl("mask", service_name)
+
+    if service_running(service_name):
+        raise SystemdError(f"Attempted to pause {service_name!r}, but it is still running.")
+
+    return True
+
+
+def service_resume(service_name: str) -> bool:
+    """Resume a system service.
+
+    Re-enable starting the service again at boot. Start the service.
+
+    Args:
+        service_name: The name of the service to resume.
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if service is not running after being resumed by systemctl.
+    """
+    _systemctl("unmask", service_name)
+    _systemctl("enable", "--now", service_name)
+
+    if not service_running(service_name):
+        raise SystemdError(f"Attempted to resume {service_name!r}, but it is not running.")
+
+    return True
+
+
+def daemon_reload() -> bool:
+    """Reload systemd manager configuration.
+
+    Returns:
+        On success, this function returns True for historical reasons.
+
+    Raises:
+        SystemdError: Raised if `systemctl daemon-reload` returns a non-zero returncode.
+    """
+    return _systemctl("daemon-reload", check=True) == 0

--- a/src/bind.py
+++ b/src/bind.py
@@ -178,7 +178,7 @@ class BindService:
                     zones[new_zone.domain].entries.update(new_zone.entries)
                 else:
                     zones[new_zone.domain] = new_zone
-        return list(zones)
+        return list(zones.values())
 
     def _get_conflicts(self, zones: list[Zone]) -> tuple[set[DnsEntry], set[DnsEntry]]:
         """Return conflicting and non-conflicting entries.

--- a/src/bind.py
+++ b/src/bind.py
@@ -161,7 +161,7 @@ class BindService:
 
     def _dns_record_relations_data_to_zones(
         self,
-        relation_data: typing.List[typing.Tuple[DNSRecordRequirerData, DNSRecordProviderData]],
+        relation_data: list[tuple[DNSRecordRequirerData, DNSRecordProviderData]],
     ) -> list[Zone]:
         """Return zones from all the dns_record relations data.
 
@@ -171,7 +171,7 @@ class BindService:
         Returns:
             The zones from the record_requirer_data
         """
-        zones: typing.List[Zone] = []
+        zones: list[Zone] = []
         for record_requirer_data, _ in relation_data:
             for new_zone in self._record_requirer_data_to_zones(record_requirer_data):
                 # If the new zone is already in the list, merge with it
@@ -185,8 +185,8 @@ class BindService:
         return zones
 
     def _get_conflicts(
-        self, zones: typing.List[Zone]
-    ) -> typing.Tuple[typing.Set[DnsEntry], typing.Set[DnsEntry]]:
+        self, zones: list[Zone]
+    ) -> tuple[set[DnsEntry], set[DnsEntry]]:
         """Return conflicting and non-conflicting entries.
 
         Args:
@@ -258,7 +258,7 @@ class BindService:
 
     def update_zonefiles_and_reload(
         self,
-        relation_data: typing.List[typing.Tuple[DNSRecordRequirerData, DNSRecordProviderData]],
+        relation_data: list[tuple[DNSRecordRequirerData, DNSRecordProviderData]],
     ) -> None:
         """Update the zonefiles from bind's config and reload bind.
 
@@ -269,7 +269,7 @@ class BindService:
         # Create staging area
         with tempfile.TemporaryDirectory() as tempdir:
             # Write zone files
-            zone_files: typing.Dict[str, str] = self._zones_to_files_content(zones)
+            zone_files: dict[str, str] = self._zones_to_files_content(zones)
             for domain, content in zone_files.items():
                 pathlib.Path(tempdir, f"db.{domain}").write_text(content, encoding="utf-8")
 

--- a/src/bind.py
+++ b/src/bind.py
@@ -171,18 +171,14 @@ class BindService:
         Returns:
             The zones from the record_requirer_data
         """
-        zones: list[Zone] = []
+        zones: dict[Zone] = {}
         for record_requirer_data, _ in relation_data:
             for new_zone in self._record_requirer_data_to_zones(record_requirer_data):
-                # If the new zone is already in the list, merge with it
-                if any(zone.domain == new_zone.domain for zone in zones):
-                    for zone in zones:
-                        if zone.domain == new_zone.domain:
-                            zone.entries.update(new_zone.entries)
+                if new_zone.domain in zones:
+                    zones[new_zone.domain].entries.update(new_zone.entries)
                 else:
-                    # If the new zone wasn't in the list, add it
-                    zones.append(new_zone)
-        return zones
+                    zones[new_zone.domain] = new_zone
+        return zones.values()
 
     def _get_conflicts(self, zones: list[Zone]) -> tuple[set[DnsEntry], set[DnsEntry]]:
         """Return conflicting and non-conflicting entries.

--- a/src/bind.py
+++ b/src/bind.py
@@ -263,6 +263,12 @@ class BindService:
             The DNSRecordProviderData with the status of each request
         """
         zones = self._dns_record_relations_data_to_zones(relation_data)
+
+        # Check for conflicts
+        _, conflicting = self._get_conflicts(zones)
+        if len(conflicting) > 0:
+            return self._create_dns_record_provider_data(relation_data)
+
         # Create staging area
         with tempfile.TemporaryDirectory() as tempdir:
             # Write zone files

--- a/src/bind.py
+++ b/src/bind.py
@@ -59,7 +59,7 @@ class BindService:
             cache = snap.SnapCache()
             charmed_bind = cache[constants.DNS_SNAP_NAME]
             charmed_bind_service = charmed_bind.services[constants.DNS_SNAP_SERVICE]
-            if charmed_bind_service['active'] or force_start:
+            if charmed_bind_service["active"] or force_start:
                 charmed_bind.restart(reload=True)
         except snap.SnapError as e:
             error_msg = (
@@ -184,9 +184,7 @@ class BindService:
                     zones.append(new_zone)
         return zones
 
-    def _get_conflicts(
-        self, zones: list[Zone]
-    ) -> tuple[set[DnsEntry], set[DnsEntry]]:
+    def _get_conflicts(self, zones: list[Zone]) -> tuple[set[DnsEntry], set[DnsEntry]]:
         """Return conflicting and non-conflicting entries.
 
         Args:
@@ -259,11 +257,14 @@ class BindService:
     def update_zonefiles_and_reload(
         self,
         relation_data: list[tuple[DNSRecordRequirerData, DNSRecordProviderData]],
-    ) -> None:
+    ) -> DNSRecordProviderData:
         """Update the zonefiles from bind's config and reload bind.
 
         Args:
             relation_data: input relation data
+
+        Returns:
+            The DNSRecordProviderData with the status of each request
         """
         zones = self._dns_record_relations_data_to_zones(relation_data)
         # Create staging area

--- a/src/bind.py
+++ b/src/bind.py
@@ -171,14 +171,14 @@ class BindService:
         Returns:
             The zones from the record_requirer_data
         """
-        zones: dict[Zone] = {}
+        zones: dict[str, Zone] = {}
         for record_requirer_data, _ in relation_data:
             for new_zone in self._record_requirer_data_to_zones(record_requirer_data):
                 if new_zone.domain in zones:
                     zones[new_zone.domain].entries.update(new_zone.entries)
                 else:
                     zones[new_zone.domain] = new_zone
-        return zones.values()
+        return list(zones)
 
     def _get_conflicts(self, zones: list[Zone]) -> tuple[set[DnsEntry], set[DnsEntry]]:
         """Return conflicting and non-conflicting entries.

--- a/src/bind.py
+++ b/src/bind.py
@@ -411,6 +411,7 @@ class BindService:
         Raises:
             InvalidZoneFileMetadataError: when the metadata of the zonefile could not be parsed.
             EmptyZoneFileMetadataError: when the metadata of the zonefile is empty.
+            DuplicateMetadataEntryError: when the metadata of the zonefile has duplicate entries.
         """
         # This assumes that the file was generated with the constants.ZONE_HEADER_TEMPLATE template
         metadata = {}
@@ -423,9 +424,12 @@ class BindService:
                 logger.debug("%s", line)
                 for token in line.split(";")[1].split():
                     k, v = token.split(":")
+                    if k in metadata:
+                        raise exceptions.DuplicateMetadataEntryError(
+                            f"Duplicate metadata entry '{k}'"
+                        )
                     metadata[k] = v
                 logger.debug("%s", metadata)
-                break
         except (IndexError, ValueError) as err:
             raise exceptions.InvalidZoneFileMetadataError(err) from err
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -45,14 +45,14 @@ class BindCharm(ops.CharmBase):
 
         """
         try:
-            relation_requirer_data = self.dns_record.get_remote_relation_data()
+            relation_data = self.dns_record.get_remote_relation_data()
         except ValueError as err:
             logger.info("Validation error of the relation data: %s", err)
             return
         self.unit.status = ops.MaintenanceStatus("Handling new relation requests")
-        relation_provider_data = self.bind.handle_relation_data(relation_requirer_data)
+        dns_record_provider_data = self.bind.create_dns_record_provider_data(relation_data)
         relation = self.model.get_relation(self.dns_record.relation_name, event.relation.id)
-        self.dns_record.update_relation_data(relation, relation_provider_data)
+        self.dns_record.update_relation_data(relation, dns_record_provider_data)
 
     def _on_collect_status(self, event: ops.CollectStatusEvent) -> None:
         """Handle collect status event.

--- a/src/charm.py
+++ b/src/charm.py
@@ -50,7 +50,7 @@ class BindCharm(ops.CharmBase):
             logger.info("Validation error of the relation data: %s", err)
             return
         self.unit.status = ops.MaintenanceStatus("Handling new relation requests")
-        dns_record_provider_data = self.bind.create_dns_record_provider_data(relation_data)
+        dns_record_provider_data = self.bind.update_zonefiles_and_reload(relation_data)
         relation = self.model.get_relation(self.dns_record.relation_name, event.relation.id)
         self.dns_record.update_relation_data(relation, dns_record_provider_data)
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,6 +4,7 @@
 """File containing constants to be used in the charm."""
 
 DNS_SNAP_NAME = "charmed-bind"
+DNS_SNAP_SERVICE = "named"
 SNAP_PACKAGES = {
     DNS_SNAP_NAME: {"channel": "edge"},
 }

--- a/src/constants.py
+++ b/src/constants.py
@@ -10,7 +10,7 @@ SNAP_PACKAGES = {
 }
 DNS_CONFIG_DIR = f"/var/snap/{DNS_SNAP_NAME}/current/etc/bind"
 
-ZONE_HEADER_TEMPLATE = """$ORIGIN {zone}.
+ZONE_HEADER_TEMPLATE = """$ORIGIN {zone}.; HASH:{hash}
 $TTL 600
 @ IN SOA {zone}. mail.{zone}. ( {serial} 1d 1h 1h 10m )
 @ IN NS localhost.
@@ -21,3 +21,29 @@ ZONE_RECORD_TEMPLATE = "{host_label} {record_class} {record_type} {record_data}\
 NAMED_CONF_ZONE_DEF_TEMPLATE = (
     'zone "{name}" IN {{ type primary; file "{absolute_path}"; allow-update {{ none; }}; }};\n'
 )
+
+SYSTEMD_SERVICES_PATH = "/etc/systemd/system/"
+
+DISPATCH_EVENT_SERVICE = """[Unit]
+Description=Dispatch the {event} event on {unit}
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/timeout {timeout} /usr/bin/bash -c '/usr/bin/juju-exec "{unit}" "JUJU_DISPATCH_PATH={event} ./dispatch"'
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+SYSTEMD_SERVICE_TIMER = """[Unit]
+Description=Run {service} weekly
+Requires={service}.service
+
+[Timer]
+Unit={service}.service
+OnCalendar=*-*-* *:0/{interval}
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+"""

--- a/src/events.py
+++ b/src/events.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Custom events for the charm."""
+
+import ops
+
+
+class ReloadBindEvent(ops.charm.EventBase):
+    """Event representing a periodic reload of the charmed-bind service."""

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -18,3 +18,35 @@ class SnapError(Exception):
             msg (str): Explanation of the error.
         """
         self.msg = msg
+
+
+class InvalidZoneFileMetadataError(Exception):
+    """Exception raised when a zonefile has invalid metadata.
+
+    Attrs:
+        msg (str): Explanation of the error.
+    """
+
+    def __init__(self, msg: str):
+        """Initialize a new instance of the InvalidZoneFileMetadataError exception.
+
+        Args:
+            msg (str): Explanation of the error.
+        """
+        self.msg = msg
+
+
+class EmptyZoneFileMetadataError(Exception):
+    """Exception raised when a zonefile has no metadata.
+
+    Attrs:
+        msg (str): Explanation of the error.
+    """
+
+    def __init__(self, msg: str):
+        """Initialize a new instance of the EmptyZoneFileMetadataError exception.
+
+        Args:
+            msg (str): Explanation of the error.
+        """
+        self.msg = msg

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -50,3 +50,19 @@ class EmptyZoneFileMetadataError(Exception):
             msg (str): Explanation of the error.
         """
         self.msg = msg
+
+
+class DuplicateMetadataEntryError(Exception):
+    """Exception raised when a zonefile has metadata with duplicate entries.
+
+    Attrs:
+        msg (str): Explanation of the error.
+    """
+
+    def __init__(self, msg: str):
+        """Initialize a new instance of the DuplicateMetadataEntryError exception.
+
+        Args:
+            msg (str): Explanation of the error.
+        """
+        self.msg = msg

--- a/src/models.py
+++ b/src/models.py
@@ -59,7 +59,7 @@ class Zone(pydantic.BaseModel):
     """
 
     domain: str
-    entries: list[DnsEntry]
+    entries: set[DnsEntry]
 
 
 def create_dns_entry_from_requirer_entry(requirer_entry: RequirerEntry) -> DnsEntry:

--- a/src/models.py
+++ b/src/models.py
@@ -51,7 +51,7 @@ class DnsEntry(pydantic.BaseModel):
         h = hashlib.blake2b()
         for data in (getattr(self, k) for k in self.__dict__):
             h.update(str(data).encode())
-        return int.from_bytes(h.digest(), byteorder='big')
+        return int.from_bytes(h.digest(), byteorder="big")
 
 
 class Zone(pydantic.BaseModel):
@@ -73,8 +73,8 @@ class Zone(pydantic.BaseModel):
         """
         h = hashlib.blake2b()
         for entry_hash in (hash(e) for e in self.entries):
-            h.update(entry_hash.to_bytes(length=1, byteorder='big'))
-        return int.from_bytes(h.digest(), byteorder='big')
+            h.update(entry_hash.to_bytes(length=1, byteorder="big"))
+        return int.from_bytes(h.digest(), byteorder="big")
 
 
 def create_dns_entry_from_requirer_entry(requirer_entry: RequirerEntry) -> DnsEntry:

--- a/src/models.py
+++ b/src/models.py
@@ -61,6 +61,14 @@ class Zone(pydantic.BaseModel):
     domain: str
     entries: set[DnsEntry]
 
+    def __hash__(self) -> int:
+        """Get a hash of a Zone based on its DNSEntries.
+
+        Returns:
+            A hash for the current object.
+        """
+        return hash(tuple(hash(e) for e in self.entries))
+
 
 def create_dns_entry_from_requirer_entry(requirer_entry: RequirerEntry) -> DnsEntry:
     """Create a DnsEntry from a RequirerEntry.

--- a/src/models.py
+++ b/src/models.py
@@ -51,7 +51,7 @@ class DnsEntry(pydantic.BaseModel):
         h = hashlib.blake2b()
         for data in (getattr(self, k) for k in self.__dict__):
             h.update(str(data).encode())
-        return int.from_bytes(h.digest())
+        return int.from_bytes(h.digest(), byteorder='big')
 
 
 class Zone(pydantic.BaseModel):
@@ -73,8 +73,8 @@ class Zone(pydantic.BaseModel):
         """
         h = hashlib.blake2b()
         for entry_hash in (hash(e) for e in self.entries):
-            h.update(entry_hash.to_bytes())
-        return int.from_bytes(h.digest())
+            h.update(entry_hash.to_bytes(length=1, byteorder='big'))
+        return int.from_bytes(h.digest(), byteorder='big')
 
 
 def create_dns_entry_from_requirer_entry(requirer_entry: RequirerEntry) -> DnsEntry:

--- a/src/models.py
+++ b/src/models.py
@@ -73,7 +73,7 @@ class Zone(pydantic.BaseModel):
         """
         h = hashlib.blake2b()
         for entry_hash in (hash(e) for e in self.entries):
-            h.update(entry_hash.to_bytes(length=1, byteorder="big"))
+            h.update(entry_hash.to_bytes((entry_hash.bit_length() + 7) // 8, byteorder="big"))
         return int.from_bytes(h.digest(), byteorder="big")
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -261,7 +261,9 @@ async def test_dns_record_relation(
         for integration_data in integration_datasets:
             for entry in integration_data:
 
-                result = await tests.integration.helpers.dig_query(ops_test, app.name, entry, retry=True, wait=5)
+                result = await tests.integration.helpers.dig_query(
+                    ops_test, app.name, entry, retry=True, wait=5
+                )
                 assert result == str(entry.record_data), (
                     f"{entry.host_label}.{entry.domain}"
                     f" {entry.record_type} {entry.record_data}"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -40,6 +40,12 @@ async def test_lifecycle(app: ops.model.Application, ops_test: OpsTest):
     logger.info(service_status)
     assert "inactive" in service_status
 
+    # Wait a bit and retest the status.
+    # This is done to make sure that bind-reload doesn't restart the service
+    time.sleep(70)
+    logger.info(service_status)
+    assert "inactive" in service_status
+
     await tests.integration.helpers.dispatch_to_unit(ops_test, unit, "start")
     time.sleep(5)
     _, service_status, _ = await ops_test.juju(
@@ -66,6 +72,10 @@ async def test_basic_dns_config(app: ops.model.Application, ops_test: OpsTest):
     allow-update {{ none; }};
 }};
     """
+    # We need to stop the dispatch-reload-bind timer for this test
+    stop_timer_cmd = "sudo systemctl stop dispatch-reload-bind.timer"
+    await tests.integration.helpers.run_on_unit(ops_test, unit.name, stop_timer_cmd)
+
     await tests.integration.helpers.push_to_unit(
         ops_test, unit, test_zone_def, f"{constants.DNS_CONFIG_DIR}/named.conf.local"
     )
@@ -94,6 +104,10 @@ async def test_basic_dns_config(app: ops.model.Application, ops_test: OpsTest):
             ops_test, f"{app.name}/{0}", "dig @127.0.0.1 dns.test TXT +short"
         )
     ).strip() == '"this-is-a-test"'
+
+    # Restart the timer for the subsequent tests
+    start_timer_cmd = "sudo systemctl start dispatch-reload-bind.timer"
+    await tests.integration.helpers.run_on_unit(ops_test, unit.name, start_timer_cmd)
 
 
 @pytest.mark.parametrize(
@@ -223,6 +237,13 @@ async def test_dns_record_relation(
         )
         any_app_number += 1
 
+    await model.wait_for_idle()
+
+    # wait for the bind-reload event to happen
+    restart_cmd = f"sudo snap restart --reload {constants.DNS_SNAP_NAME}"
+    # Application actually does have units
+    unit = app.units[0]  # type: ignore
+    await tests.integration.helpers.run_on_unit(ops_test, unit.name, restart_cmd)
     await model.wait_for_idle()
 
     # Test the status of the bind-operator instance

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -237,8 +237,6 @@ async def test_dns_record_relation(
             for entry in integration_data:
 
                 result = await tests.integration.helpers.dig_query(ops_test, app.name, entry)
-                await model.wait_for_idle()
-
                 assert result == str(entry.record_data), (
                     f"{entry.host_label}.{entry.domain}"
                     f" {entry.record_type} {entry.record_data}"

--- a/tests/unit/test_bind.py
+++ b/tests/unit/test_bind.py
@@ -4,7 +4,6 @@
 """Unit tests for the bind module."""
 
 import uuid
-import itertools
 
 import pytest
 from charms.bind.v0 import dns_record

--- a/tests/unit/test_bind.py
+++ b/tests/unit/test_bind.py
@@ -168,6 +168,21 @@ def test_get_conflicts(integration_datasets, zones_name, nonconflicting, conflic
         ("", {}, exceptions.EmptyZoneFileMetadataError),
         ("sometext; someothertext", {}, exceptions.EmptyZoneFileMetadataError),
         ("$ORIGIN test.dns.test.; HASH:1234", {"HASH": "1234"}, None),
+        (
+            "$ORIGIN test.dns.test.; HASH:1234\n$ORIGIN test2.dns.test.; PLOP:plop",
+            {"HASH": "1234", "PLOP": "plop"},
+            None,
+        ),
+        (
+            "$ORIGIN test.dns.test.; HASH:1234 HASH:4567",
+            {},
+            exceptions.DuplicateMetadataEntryError,
+        ),
+        (
+            "$ORIGIN test.dns.test.; HASH:1234\n$ORIGIN test2.dns.test.; HASH:4567",
+            {},
+            exceptions.DuplicateMetadataEntryError,
+        ),
         ("$ORIGIN test.dns.test.; HASH::", None, exceptions.InvalidZoneFileMetadataError),
         ("$ORIGIN test.dns.test.;    ", {"HASH": "1234"}, exceptions.EmptyZoneFileMetadataError),
         (

--- a/tests/unit/test_bind.py
+++ b/tests/unit/test_bind.py
@@ -4,6 +4,7 @@
 """Unit tests for the bind module."""
 
 import uuid
+import itertools
 
 import pytest
 from charms.bind.v0 import dns_record
@@ -13,81 +14,108 @@ import models
 
 
 @pytest.mark.parametrize(
-    "integration_datasets, nonconflicting, conflicting",
+    "integration_datasets, zones_name, nonconflicting, conflicting",
     (
         (
             [
-                models.DnsEntry(
-                    domain="dns.test",
-                    host_label="admin",
-                    ttl=600,
-                    record_class="IN",
-                    record_type="A",
-                    record_data="42.42.42.42",
-                ),
-                models.DnsEntry(
-                    domain="dns.test",
-                    host_label="admin",
-                    ttl=600,
-                    record_class="IN",
-                    record_type="A",
-                    record_data="42.42.42.42",
-                ),
+                [
+                    models.DnsEntry(
+                        domain="dns.test",
+                        host_label="admin",
+                        ttl=600,
+                        record_class="IN",
+                        record_type="A",
+                        record_data="42.42.42.42",
+                    ),
+                    models.DnsEntry(
+                        domain="dns.test",
+                        host_label="admin",
+                        ttl=600,
+                        record_class="IN",
+                        record_type="A",
+                        record_data="42.42.42.42",
+                    ),
+                ],
+                [
+                    models.DnsEntry(
+                        domain="dns.test",
+                        host_label="admin",
+                        ttl=600,
+                        record_class="IN",
+                        record_type="A",
+                        record_data="42.42.42.42",
+                    ),
+                    models.DnsEntry(
+                        domain="dns2.test",
+                        host_label="admin",
+                        ttl=600,
+                        record_class="IN",
+                        record_type="A",
+                        record_data="42.42.42.43",
+                    ),
+                ],
             ],
-            {0},
+            {"dns.test", "dns2.test"},
+            {"admin.dns.test", "admin.dns2.test"},
             set(),
         ),
         (
             [
-                models.DnsEntry(
-                    domain="dns.test",
-                    host_label="admin",
-                    ttl=600,
-                    record_class="IN",
-                    record_type="A",
-                    record_data="42.42.42.42",
-                ),
-                models.DnsEntry(
-                    domain="dns2.test",
-                    host_label="admin",
-                    ttl=600,
-                    record_class="IN",
-                    record_type="A",
-                    record_data="41.41.41.41",
-                ),
-                models.DnsEntry(
-                    domain="dns.test",
-                    host_label="admin2",
-                    ttl=600,
-                    record_class="IN",
-                    record_type="A",
-                    record_data="40.40.40.40",
-                ),
+                [
+                    models.DnsEntry(
+                        domain="dns.test",
+                        host_label="admin",
+                        ttl=600,
+                        record_class="IN",
+                        record_type="A",
+                        record_data="42.42.42.42",
+                    ),
+                    models.DnsEntry(
+                        domain="dns2.test",
+                        host_label="admin",
+                        ttl=600,
+                        record_class="IN",
+                        record_type="A",
+                        record_data="41.41.41.41",
+                    ),
+                    models.DnsEntry(
+                        domain="dns.test",
+                        host_label="admin2",
+                        ttl=600,
+                        record_class="IN",
+                        record_type="A",
+                        record_data="40.40.40.40",
+                    ),
+                ],
             ],
-            {0, 1, 2},
+            {"dns.test", "dns2.test"},
+            {"admin.dns.test", "admin.dns2.test", "admin2.dns.test"},
             set(),
         ),
         (
             [
-                models.DnsEntry(
-                    domain="dns.test",
-                    host_label="admin",
-                    ttl=600,
-                    record_class="IN",
-                    record_type="A",
-                    record_data="42.42.42.42",
-                ),
-                models.DnsEntry(
-                    domain="dns.test",
-                    host_label="admin",
-                    ttl=600,
-                    record_class="IN",
-                    record_type="A",
-                    record_data="41.41.41.41",
-                ),
+                [
+                    models.DnsEntry(
+                        domain="dns.test",
+                        host_label="admin",
+                        ttl=600,
+                        record_class="IN",
+                        record_type="A",
+                        record_data="42.42.42.42",
+                    ),
+                    models.DnsEntry(
+                        domain="dns.test",
+                        host_label="admin",
+                        ttl=600,
+                        record_class="IN",
+                        record_type="A",
+                        record_data="41.41.41.41",
+                    ),
+                ],
             ],
+            {"dns.test"},
             set(),
-            {0, 1},
+            {"admin.dns.test"},
         ),
     ),
     ids=(
@@ -96,38 +124,39 @@ import models
         "Basic conflict",
     ),
 )
-def test_get_conflicts(integration_datasets, nonconflicting, conflicting):
+def test_get_conflicts(integration_datasets, zones_name, nonconflicting, conflicting):
     """
-    arrange: prepare some integration dataset
+    arrange: prepare some integration datasets
     act: generate conflicting sets of DnsEntries
     assert: that the generate set is what we expected
     """
-    requirer_entries = [
-        dns_record.RequirerEntry(
-            domain=e.domain,
-            host_label=e.host_label,
-            ttl=e.ttl,
-            record_class=e.record_class,
-            record_type=e.record_type,
-            record_data=e.record_data,
-            uuid=uuid.uuid4(),
+    record_requirers_data = []
+    for requirer in integration_datasets:
+        requirer_entries = [
+            dns_record.RequirerEntry(
+                domain=e.domain,
+                host_label=e.host_label,
+                ttl=e.ttl,
+                record_class=e.record_class,
+                record_type=e.record_type,
+                record_data=e.record_data,
+                uuid=uuid.uuid4(),
+            )
+            for e in requirer
+        ]
+        record_requirer_data = dns_record.DNSRecordRequirerData(
+            dns_entries=requirer_entries,
+            service_account="fakeserviceaccount",
         )
-        for e in integration_datasets
-    ]
-    record_requirer_data = dns_record.DNSRecordRequirerData(
-        dns_entries=requirer_entries,
-        service_account="fakeserviceaccount",
-    )
+        record_requirers_data.append(record_requirer_data)
 
     bind_service = bind.BindService()
 
-    zones = bind_service._record_requirer_data_to_zones(  # pylint: disable=protected-access
-        record_requirer_data
+    zones = bind_service._dns_record_relations_data_to_zones(  # pylint: disable=protected-access
+        [(record_requirer_data, None) for record_requirer_data in record_requirers_data]
     )
+    assert zones_name == {zone.domain for zone in zones}
+
     output = bind_service._get_conflicts(zones)  # pylint: disable=protected-access
-
-    nonconflicting = {e for i, e in enumerate(integration_datasets) if i in nonconflicting}
-    conflicting = {e for i, e in enumerate(integration_datasets) if i in conflicting}
-
-    assert nonconflicting == output[0]
-    assert conflicting == output[1]
+    assert nonconflicting == {f"{e.host_label}.{e.domain}" for e in output[0]}
+    assert conflicting == {f"{e.host_label}.{e.domain}" for e in output[1]}

--- a/tests/unit/test_bind.py
+++ b/tests/unit/test_bind.py
@@ -9,6 +9,7 @@ import pytest
 from charms.bind.v0 import dns_record
 
 import bind
+import exceptions
 import models
 
 
@@ -159,3 +160,36 @@ def test_get_conflicts(integration_datasets, zones_name, nonconflicting, conflic
     output = bind_service._get_conflicts(zones)  # pylint: disable=protected-access
     assert nonconflicting == {f"{e.host_label}.{e.domain}" for e in output[0]}
     assert conflicting == {f"{e.host_label}.{e.domain}" for e in output[1]}
+
+
+@pytest.mark.parametrize(
+    "zonefile_content, metadata, error",
+    (
+        ("", {}, exceptions.EmptyZoneFileMetadataError),
+        ("sometext; someothertext", {}, exceptions.EmptyZoneFileMetadataError),
+        ("$ORIGIN test.dns.test.; HASH:1234", {"HASH": "1234"}, None),
+        ("$ORIGIN test.dns.test.; HASH::", None, exceptions.InvalidZoneFileMetadataError),
+        ("$ORIGIN test.dns.test.;    ", {"HASH": "1234"}, exceptions.EmptyZoneFileMetadataError),
+        (
+            "\n\nsometext\n\n$ORIGIN test.dns.test.; HASH:1234 PLOP:plop\nsomeothertext",
+            {"HASH": "1234", "PLOP": "plop"},
+            None,
+        ),
+    ),
+)
+def test_get_zonefile_metadata(zonefile_content: str, metadata: dict[str, str], error):
+    """
+    arrange: nothing
+    act: get the metadata from the zonefile_content
+    assert: the correct metadata should be found or the correct exception raised
+    """
+    bind_service = bind.BindService()
+    if error is not None:
+        with pytest.raises(error):
+            bind_service._get_zonefile_metadata(  # pylint: disable=protected-access
+                zonefile_content
+            )
+    else:
+        assert metadata == bind_service._get_zonefile_metadata(  # pylint: disable=protected-access
+            zonefile_content
+        )


### PR DESCRIPTION
### Overview

Reload the bind service on a timer instead of after every change in requests.  
This is done by installing a service and a timer that regularly (every minute) dispatch a custom event to the charm.  
The charm then calculates the hash of each zone and compares it with the current one stored as metadata in the zonefile. If at least one hash differs, it reloads bind.

### Rationale

The goal is to avoid spammy changes in requests which could over reload bind.

### Juju Events Changes

A new custom event was added: `ReloadBindEvent`, that triggers the change verification and reloading of bind.

### Module Changes

Upon receiving a change in the dns record requests, the charm doesn't reload bind anymore but only replies with the status of the requests (valid or conflicting).

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)