### PR TITLE
Handle configuration for active/standby units

### DIFF
--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,0 +1,5 @@
+ignore_files:
+  # Ignore some files as they use non compliant terminology:
+  # masterfile-format
+  # masterfile-style
+  - src/constants.py

--- a/src/bind.py
+++ b/src/bind.py
@@ -6,11 +6,13 @@
 import logging
 import os
 import pathlib
+import re
 import shutil
 import tempfile
 import time
 
 import ops
+import pydantic
 from charms.bind.v0.dns_record import (
     DNSProviderData,
     DNSRecordProviderData,
@@ -23,7 +25,7 @@ from charms.operator_libs_linux.v2 import snap
 
 import constants
 import exceptions
-from models import DnsEntry, Zone, create_dns_entry_from_requirer_entry
+import models
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +133,7 @@ class BindService:
             snap_channel=constants.SNAP_PACKAGES[constants.DNS_SNAP_NAME]["channel"],
         )
         self._install_bind_reload_service(unit_name)
-        self.update_zonefiles_and_reload([])
+        self.update_zonefiles_and_reload([], None)
 
     def _install_bind_reload_service(self, unit_name: str) -> None:
         """Install the bind reload service.
@@ -167,7 +169,7 @@ class BindService:
             event: Event triggering the collect-status hook
             relation_data: data coming from the relation databag
         """
-        zones: list[Zone] = []
+        zones: list[models.Zone] = []
         for record_requirer_data, _ in relation_data:
             zones.extend(self._record_requirer_data_to_zones(record_requirer_data))
         _, conflicting = self._get_conflicts(zones)
@@ -178,13 +180,17 @@ class BindService:
     def update_zonefiles_and_reload(
         self,
         relation_data: list[tuple[DNSRecordRequirerData, DNSRecordProviderData]],
+        topology: models.Topology | None,
     ) -> None:
         """Update the zonefiles from bind's config and reload bind.
 
         Args:
             relation_data: input relation data
+            topology: Topology of the current deployment
         """
+        logger.debug("Starting update of zonefiles")
         zones = self._dns_record_relations_data_to_zones(relation_data)
+        logger.debug("Zones: %s", [z.domain for z in zones])
 
         # Check for conflicts
         _, conflicting = self._get_conflicts(zones)
@@ -202,14 +208,16 @@ class BindService:
                 encoding="utf-8",
             )
 
-            # Write zone files
-            zone_files: dict[str, str] = self._zones_to_files_content(zones)
-            for domain, content in zone_files.items():
-                pathlib.Path(tempdir, f"db.{domain}").write_text(content, encoding="utf-8")
+            if topology is not None and topology.is_current_unit_active:
+                # Write zone files
+                zone_files: dict[str, str] = self._zones_to_files_content(zones)
+                for domain, content in zone_files.items():
+                    pathlib.Path(tempdir, f"db.{domain}").write_text(content, encoding="utf-8")
 
             # Write the named.conf file
             pathlib.Path(tempdir, "named.conf.local").write_text(
-                self._generate_named_conf_local([z.domain for z in zones]), encoding="utf-8"
+                self._generate_named_conf_local([z.domain for z in zones], topology),
+                encoding="utf-8",
             )
 
             # Move the valid staging area files to the config dir
@@ -239,7 +247,7 @@ class BindService:
         statuses = []
         for record_requirer_data, _ in relation_data:
             for requirer_entry in record_requirer_data.dns_entries:
-                dns_entry = create_dns_entry_from_requirer_entry(requirer_entry)
+                dns_entry = models.create_dns_entry_from_requirer_entry(requirer_entry)
                 if dns_entry in nonconflicting:
                     statuses.append(
                         DNSProviderData(uuid=requirer_entry.uuid, status=Status.APPROVED)
@@ -256,16 +264,19 @@ class BindService:
     def has_a_zone_changed(
         self,
         relation_data: list[tuple[DNSRecordRequirerData, DNSRecordProviderData]],
+        topology: models.Topology | None,
     ) -> bool:
         """Check if a zone definition has changed.
 
         Args:
             relation_data: input relation data
+            topology: Topology of the current deployment
 
         Returns:
             True if a zone has changed, False otherwise.
         """
         zones = self._dns_record_relations_data_to_zones(relation_data)
+        logger.debug("Zones: %s", [z.domain for z in zones])
         for zone in zones:
             try:
                 zonefile_content = pathlib.Path(
@@ -279,7 +290,15 @@ class BindService:
             ):
                 return True
             if "HASH" in metadata and hash(zone) != int(metadata["HASH"]):
+                logger.debug("Config hash has changed !")
                 return True
+
+        if topology is not None and topology.is_current_unit_active:
+            return (
+                self._get_secondaries_ip_from_conf().sort()
+                != [str(ip) for ip in topology.standby_units_ip].sort()
+            )
+
         return False
 
     def _install_snap_package(
@@ -309,7 +328,7 @@ class BindService:
 
     def _record_requirer_data_to_zones(
         self, record_requirer_data: DNSRecordRequirerData
-    ) -> list[Zone]:
+    ) -> list[models.Zone]:
         """Convert DNSRecordRequirerData to zone files.
 
         Args:
@@ -324,15 +343,17 @@ class BindService:
                 zones_entries[entry.domain] = []
             zones_entries[entry.domain].append(entry)
 
-        zones: list[Zone] = []
+        zones: list[models.Zone] = []
         for domain, entries in zones_entries.items():
-            zone = Zone(domain=domain, entries=[])
+            zone = models.Zone(domain=domain, entries=[])
             for entry in entries:
-                zone.entries.add(create_dns_entry_from_requirer_entry(entry))
+                zone.entries.add(models.create_dns_entry_from_requirer_entry(entry))
             zones.append(zone)
         return zones
 
-    def _get_conflicts(self, zones: list[Zone]) -> tuple[set[DnsEntry], set[DnsEntry]]:
+    def _get_conflicts(
+        self, zones: list[models.Zone]
+    ) -> tuple[set[models.DnsEntry], set[models.DnsEntry]]:
         """Return conflicting and non-conflicting entries.
 
         Args:
@@ -342,8 +363,8 @@ class BindService:
             A tuple containing the non-conflicting and conflicting entries
         """
         entries = [e for z in zones for e in z.entries]
-        nonconflicting_entries: set[DnsEntry] = set()
-        conflicting_entries: set[DnsEntry] = set()
+        nonconflicting_entries: set[models.DnsEntry] = set()
+        conflicting_entries: set[models.DnsEntry] = set()
         while entries:
             entry = entries.pop()
             found_conflict = False
@@ -360,7 +381,7 @@ class BindService:
 
         return (nonconflicting_entries, conflicting_entries)
 
-    def _zones_to_files_content(self, zones: list[Zone]) -> dict[str, str]:
+    def _zones_to_files_content(self, zones: list[models.Zone]) -> dict[str, str]:
         """Return zone files and their content.
 
         Args:
@@ -390,11 +411,27 @@ class BindService:
 
         return zone_files
 
-    def _generate_named_conf_local(self, zones: list[str]) -> str:
+    def _bind_config_ip_list(self, ips: list[pydantic.IPvAnyAddress]) -> str:
+        """Generate a string with a list of IPs that can be used in bind's config.
+
+        Args:
+            ips: A list of IPs
+
+        Returns:
+            A ";" separated list of ips
+        """
+        if not ips:
+            return ""
+        return f"{';'.join([str(ip) for ip in ips])};"
+
+    def _generate_named_conf_local(
+        self, zones: list[str], topology: models.Topology | None
+    ) -> str:
         """Generate the content of `named.conf.local`.
 
         Args:
             zones: A list of all the zones names
+            topology: Topology of the current deployment
 
         Returns:
             The content of `named.conf.local`
@@ -402,20 +439,32 @@ class BindService:
         # It's good practice to include rfc1918
         content: str = f'include "{constants.DNS_CONFIG_DIR}/zones.rfc1918";\n'
         # Include a zone specifically used for some services tests
-        content += constants.NAMED_CONF_ZONE_DEF_TEMPLATE.format(
+        content += constants.NAMED_CONF_PRIMARY_ZONE_DEF_TEMPLATE.format(
             name=f"{constants.ZONE_SERVICE_NAME}",
             absolute_path=f"{constants.DNS_CONFIG_DIR}/db.{constants.ZONE_SERVICE_NAME}",
+            zone_transfer_ips="",
         )
         for name in zones:
-            content += constants.NAMED_CONF_ZONE_DEF_TEMPLATE.format(
-                name=name, absolute_path=f"{constants.DNS_CONFIG_DIR}/db.{name}"
-            )
+            if topology is None:
+                pass
+            elif topology.is_current_unit_active:
+                content += constants.NAMED_CONF_PRIMARY_ZONE_DEF_TEMPLATE.format(
+                    name=name,
+                    absolute_path=f"{constants.DNS_CONFIG_DIR}/db.{name}",
+                    zone_transfer_ips=self._bind_config_ip_list(topology.standby_units_ip),
+                )
+            else:
+                content += constants.NAMED_CONF_SECONDARY_ZONE_DEF_TEMPLATE.format(
+                    name=name,
+                    absolute_path=f"{constants.DNS_CONFIG_DIR}/db.{name}",
+                    primary_ip=self._bind_config_ip_list([topology.active_unit_ip]),
+                )
         return content
 
     def _dns_record_relations_data_to_zones(
         self,
         relation_data: list[tuple[DNSRecordRequirerData, DNSRecordProviderData]],
-    ) -> list[Zone]:
+    ) -> list[models.Zone]:
         """Return zones from all the dns_record relations data.
 
         Args:
@@ -424,7 +473,7 @@ class BindService:
         Returns:
             The zones from the record_requirer_data
         """
-        zones: dict[str, Zone] = {}
+        zones: dict[str, models.Zone] = {}
         for record_requirer_data, _ in relation_data:
             for new_zone in self._record_requirer_data_to_zones(record_requirer_data):
                 if new_zone.domain in zones:
@@ -455,16 +504,32 @@ class BindService:
                 # We only take the $ORIGIN line into account
                 if not line.startswith("$ORIGIN"):
                     continue
-                logger.debug("%s", line)
                 for token in line.split(";")[1].split():
                     k, v = token.split(":")
                     if k in metadata:
                         raise DuplicateMetadataEntryError(f"Duplicate metadata entry '{k}'")
                     metadata[k] = v
-                logger.debug("%s", metadata)
         except (IndexError, ValueError) as err:
             raise InvalidZoneFileMetadataError(err) from err
 
         if metadata:
             return metadata
         raise EmptyZoneFileMetadataError("No metadata found !")
+
+    def _get_secondaries_ip_from_conf(self) -> list[str]:
+        """Get the secondaries IP addresses from the named.conf.local file.
+
+        Returns:
+            A list of IPs as strings
+        """
+        named_conf_content = pathlib.Path(constants.DNS_CONFIG_DIR, "named.conf.local").read_text(
+            encoding="utf-8"
+        )
+        for line in named_conf_content.splitlines():
+            if "allow-transfer" in line:
+                match = re.search(r"allow-transfer\s*\{([^}]+)\}", line)
+                ips_string = match.group(1) if match else ""
+                logger.debug(ips_string)
+                ips = [ip.strip() for ip in ips_string.split(";") if ip.strip() != ""]
+                logger.debug(ips)
+        return []

--- a/src/bind.py
+++ b/src/bind.py
@@ -528,11 +528,8 @@ class BindService:
         )
         for line in named_conf_content.splitlines():
             if "allow-transfer" in line:
-                match = re.search(r"allow-transfer\s*\{([^}]+)\}", line)
-                ips_string = match.group(1) if match else ""
-                logger.debug(ips_string)
-                ips = [ip.strip() for ip in ips_string.split(";") if ip.strip() != ""]
-                logger.debug(ips)
+                if match := re.search(r"allow-transfer\s*\{([^}]+)\}", line):
+                    return [ip.strip() for ip in match.group(1).split(";") if ip.strip() != ""]
         return []
 
     def _bind_config_ip_list(self, ips: list[pydantic.IPvAnyAddress]) -> str:

--- a/src/charm.py
+++ b/src/charm.py
@@ -155,7 +155,7 @@ class BindCharm(ops.CharmBase):
         # We check that we are still the leader when starting to process this event
         topology = self._topology()
         if self.unit.is_leader() and not topology.is_current_unit_active:
-            self._become_active(topology)
+            self._check_and_may_become_active(topology)
 
     def _on_peer_relation_departed(self, event: ops.RelationDepartedEvent) -> None:
         """Handle the peer relation departed event.
@@ -176,7 +176,7 @@ class BindCharm(ops.CharmBase):
         # We check that we are still the leader when starting to process this event
         if not topology.is_current_unit_active:
             if self.unit.is_leader():
-                self._become_active(topology)
+                self._check_and_may_become_active(topology)
         else:
             try:
                 relation_data = self.dns_record.get_remote_relation_data()
@@ -185,8 +185,8 @@ class BindCharm(ops.CharmBase):
                 return
             self.bind.update_zonefiles_and_reload(relation_data, topology)
 
-    def _become_active(self, topology: models.Topology) -> bool:
-        """Set the current unit as the active unit of the charm.
+    def _check_and_may_become_active(self, topology: models.Topology) -> bool:
+        """Check the active unit status and may become active if need be.
 
         Args:
             topology: Topology of the current deployment

--- a/src/constants.py
+++ b/src/constants.py
@@ -36,8 +36,8 @@ NAMED_CONF_PRIMARY_ZONE_DEF_TEMPLATE = (
 NAMED_CONF_SECONDARY_ZONE_DEF_TEMPLATE = (
     'zone "{name}" IN {{ '
     'type secondary; file "{absolute_path}"; '
-    'masterfile-format text; '
-    'masterfile-style full; '
+    "masterfile-format text; "
+    "masterfile-style full; "
     "primaries {{ {primary_ip} }}; }};\n"
 )
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -36,6 +36,8 @@ NAMED_CONF_PRIMARY_ZONE_DEF_TEMPLATE = (
 NAMED_CONF_SECONDARY_ZONE_DEF_TEMPLATE = (
     'zone "{name}" IN {{ '
     'type secondary; file "{absolute_path}"; '
+    'masterfile-format text; '
+    'masterfile-style full; '
     "primaries {{ {primary_ip} }}; }};\n"
 )
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -27,8 +27,16 @@ $TTL 600
 
 ZONE_RECORD_TEMPLATE = "{host_label} {record_class} {record_type} {record_data}\n"
 
-NAMED_CONF_ZONE_DEF_TEMPLATE = (
-    'zone "{name}" IN {{ type primary; file "{absolute_path}"; allow-update {{ none; }}; }};\n'
+NAMED_CONF_PRIMARY_ZONE_DEF_TEMPLATE = (
+    'zone "{name}" IN {{ '
+    'type primary; file "{absolute_path}"; allow-update {{ none; }}; '
+    "allow-transfer {{ {zone_transfer_ips} }}; }};\n"
+)
+
+NAMED_CONF_SECONDARY_ZONE_DEF_TEMPLATE = (
+    'zone "{name}" IN {{ '
+    'type secondary; file "{absolute_path}"; '
+    "primaries {{ {primary_ip} }}; }};\n"
 )
 
 SYSTEMD_SERVICES_PATH = "/etc/systemd/system/"

--- a/src/models.py
+++ b/src/models.py
@@ -72,7 +72,10 @@ class Zone(pydantic.BaseModel):
             A hash for the current object.
         """
         h = hashlib.blake2b()
-        for entry_hash in (hash(e) for e in self.entries):
+        # We sort the list of entries to make sure that the elements are always in the same order
+        # This is true because `sorted()` is guaranteed to be stable
+        # https://docs.python.org/3/library/functions.html#sorted
+        for entry_hash in sorted([hash(e) for e in self.entries]):
             h.update(entry_hash.to_bytes((entry_hash.bit_length() + 7) // 8, byteorder="big"))
         return int.from_bytes(h.digest(), byteorder="big")
 

--- a/src/models.py
+++ b/src/models.py
@@ -94,3 +94,29 @@ def create_dns_entry_from_requirer_entry(requirer_entry: RequirerEntry) -> DnsEn
         record_data=requirer_entry.record_data,
         ttl=requirer_entry.ttl,
     )
+
+
+class Topology(pydantic.BaseModel):
+    """Class used to represent the current units topology.
+
+    Attributes:
+        units_ip: IPs of all the units
+        active_unit_ip: IP of the active unit
+        standby_units_ip: IPs of the standby units
+        current_unit_ip: IP of the current unit
+        is_current_unit_active: Is the current unit active ?
+    """
+
+    units_ip: list[pydantic.IPvAnyAddress]
+    active_unit_ip: pydantic.IPvAnyAddress | None
+    standby_units_ip: list[pydantic.IPvAnyAddress]
+    current_unit_ip: pydantic.IPvAnyAddress
+
+    @property
+    def is_current_unit_active(self) -> bool:
+        """Check if the current unit is the active unit.
+
+        Returns:
+            True if the current unit is effectively the active unit.
+        """
+        return self.current_unit_ip == self.active_unit_ip

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -91,7 +91,7 @@ async def push_to_unit(
     group: str = "root",
     mode: str = "644",
 ) -> None:
-    """Push a source file to the chosen unit
+    """Push a source file to the chosen unit.
 
     Args:
         ops_test: The ops test framework instance
@@ -183,13 +183,13 @@ async def generate_anycharm_relation(
 
 
 async def dig_query(
-    ops_test: OpsTest, app: ops.model.Application, cmd: str, retry: bool = False, wait: int = 5
+    ops_test: OpsTest, unit: ops.model.Unit, cmd: str, retry: bool = False, wait: int = 5
 ) -> str:
     """Query a DnsEntry with dig.
 
     Args:
         ops_test: The ops test framework instance
-        app: Application to be used to launch the command
+        unit: Unit to be used to launch the command
         cmd: Dig command to perform
         retry: If the dig request should be retried
         wait: duration in seconds to wait between retries
@@ -197,8 +197,6 @@ async def dig_query(
     Returns: the result of the DNS query
     """
     result: str = ""
-    # Application actually does have units
-    unit = app.units[0]  # type: ignore
     for _ in range(5):
         result = (await run_on_unit(ops_test, unit.name, f"dig {cmd}")).strip()
         if (result.strip() != "" and "timed out" not in result) or not retry:
@@ -209,7 +207,7 @@ async def dig_query(
 
 
 async def get_active_unit(app: ops.model.Application, ops_test: OpsTest) -> ops.model.Unit | None:
-    """Get the current active unit if it exists
+    """Get the current active unit if it exists.
 
     Args:
         app: Application to search for an active unit
@@ -239,7 +237,7 @@ async def get_active_unit(app: ops.model.Application, ops_test: OpsTest) -> ops.
 
 
 async def check_if_active_unit_exists(app: ops.model.Application, ops_test: OpsTest) -> bool:
-    """Check if an active unit exists and is reachable
+    """Check if an active unit exists and is reachable.
 
     Args:
         app: Application to search for an active unit
@@ -267,7 +265,7 @@ async def check_if_active_unit_exists(app: ops.model.Application, ops_test: OpsT
 
     status = await dig_query(
         ops_test,
-        app,
+        unit,
         f"@{active_unit} status.{constants.ZONE_SERVICE_NAME} TXT +short",
         retry=True,
         wait=5,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -34,7 +34,7 @@ async def test_lifecycle(app: ops.model.Application, ops_test: OpsTest):
 
     status = await tests.integration.helpers.dig_query(
         ops_test,
-        app,
+        unit,
         f"@127.0.0.1 status.{constants.ZONE_SERVICE_NAME} TXT +short",
         retry=True,
         wait=5,
@@ -252,7 +252,7 @@ async def test_dns_record_relation(
     restart_cmd = f"sudo snap restart --reload {constants.DNS_SNAP_NAME}"
     # Application actually does have units
     unit = app.units[0]  # type: ignore
-    await tests.integration.helpers.run_on_unit(ops_test, unit.name, restart_cmd)
+    await tests.integration.helpers.run_on_unit(ops_test, unit, restart_cmd)
     await model.wait_for_idle()
 
     # Test the status of the bind-operator instance
@@ -266,7 +266,7 @@ async def test_dns_record_relation(
 
                 result = await tests.integration.helpers.dig_query(
                     ops_test,
-                    app,
+                    unit,
                     f"@127.0.0.1 {entry.host_label}.{entry.domain} {entry.record_type} +short",
                     retry=True,
                     wait=5,
@@ -275,33 +275,3 @@ async def test_dns_record_relation(
                     f"{entry.host_label}.{entry.domain}"
                     f" {entry.record_type} {entry.record_data}"
                 )
-
-
-@pytest.mark.asyncio
-@pytest.mark.abort_on_fail
-async def test_active_election(
-    app: ops.model.Application,
-    ops_test: OpsTest,
-    model: Model,
-):
-    """
-    arrange: given deployed bind-operator
-    act: change the number of units
-    assert: there always is an active unit
-    """
-    assert await tests.integration.helpers.check_if_active_unit_exists(app, ops_test)
-
-    assert ops_test.model is not None
-    add_unit_cmd = f"add-unit {app.name} --model={ops_test.model.info.name}"
-    await ops_test.juju(*(add_unit_cmd.split(" ")))
-    await model.wait_for_idle()
-    assert await tests.integration.helpers.check_if_active_unit_exists(app, ops_test)
-
-    active_unit = await tests.integration.helpers.get_active_unit(app, ops_test)
-    assert active_unit is not None
-    remove_unit_cmd = (
-        f"remove-unit {active_unit.name} --model={ops_test.model.info.name} --no-prompt"
-    )
-    await ops_test.juju(*(remove_unit_cmd.split(" ")))
-    await model.wait_for_idle()
-    assert await tests.integration.helpers.check_if_active_unit_exists(app, ops_test)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -110,7 +110,7 @@ async def test_basic_dns_config(app: ops.model.Application, ops_test: OpsTest):
 
     assert (
         await tests.integration.helpers.run_on_unit(
-            ops_test, f"{app.name}/{0}", "dig @127.0.0.1 dns.test TXT +short"
+            ops_test, unit.name, "dig @127.0.0.1 dns.test TXT +short"
         )
     ).strip() == '"this-is-a-test"'
 
@@ -252,7 +252,7 @@ async def test_dns_record_relation(
     restart_cmd = f"sudo snap restart --reload {constants.DNS_SNAP_NAME}"
     # Application actually does have units
     unit = app.units[0]  # type: ignore
-    await tests.integration.helpers.run_on_unit(ops_test, unit, restart_cmd)
+    await tests.integration.helpers.run_on_unit(ops_test, unit.name, restart_cmd)
     await model.wait_for_idle()
 
     # Test the status of the bind-operator instance

--- a/tests/integration/test_multi_units.py
+++ b/tests/integration/test_multi_units.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for multiple units."""
+
+import logging
+
+import ops
+import pytest
+from pytest_operator.plugin import Model, OpsTest
+
+import models
+import tests.integration.helpers
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_multi_units(
+    app: ops.model.Application,
+    ops_test: OpsTest,
+    model: Model,
+):
+    """
+    arrange: given deployed bind-operator
+    act: change the number of units
+    assert: there always is an active unit
+    """
+    # Remove previously deployed instances of any-app
+    for any_app_number in range(10):
+        anyapp_name = f"anyapp-t{any_app_number}"
+        if anyapp_name in model.applications:
+            await model.remove_application(anyapp_name, block_until_done=True)
+
+    # Start by deploying the any-app instance with the domain to check
+    await tests.integration.helpers.generate_anycharm_relation(
+        app,
+        ops_test,
+        "anyapp-t1",
+        [
+            models.DnsEntry(
+                domain="dns.test",
+                host_label="admin",
+                ttl=600,
+                record_class="IN",
+                record_type="A",
+                record_data="42.42.42.42",
+            ),
+        ],
+    )
+    await model.wait_for_idle()
+
+    # Define the test that we're going to make multiple times
+    async def assert_has_dns_record(unit: ops.model.Unit):
+        """Test if the unit exposes the target DNS record.
+
+        Args:
+            unit: Unit to test
+        """
+        result = await tests.integration.helpers.dig_query(
+            ops_test,
+            unit,
+            "@127.0.0.1 admin.dns.test A +short",
+            retry=True,
+            wait=5,
+        )
+        assert result == "42.42.42.42", f"Issue with {unit.name}"
+
+    # Start by testing that everything is fine
+    assert await tests.integration.helpers.check_if_active_unit_exists(app, ops_test)
+    # Application actually does have units
+    for unit in app.units:  # type: ignore
+        await assert_has_dns_record(unit)
+
+    # add a unit and verify that everything goes well
+    assert ops_test.model is not None
+    add_unit_cmd = f"add-unit {app.name} --model={ops_test.model.info.name}"
+    await ops_test.juju(*(add_unit_cmd.split(" ")))
+    await model.wait_for_idle()
+    assert await tests.integration.helpers.check_if_active_unit_exists(app, ops_test)
+    # Application actually does have units
+    for unit in app.units:  # type: ignore
+        await assert_has_dns_record(unit)
+
+    # remove the active unit and check that we're still all right
+    active_unit = await tests.integration.helpers.get_active_unit(app, ops_test)
+    assert active_unit is not None
+    remove_unit_cmd = (
+        f"remove-unit {active_unit.name} --model={ops_test.model.info.name} --no-prompt"
+    )
+    await ops_test.juju(*(remove_unit_cmd.split(" ")))
+    await model.wait_for_idle()
+    assert await tests.integration.helpers.check_if_active_unit_exists(app, ops_test)
+    # Application actually does have units
+    for unit in app.units:  # type: ignore
+        await assert_has_dns_record(unit)


### PR DESCRIPTION
### Overview

The goal here is to differentiate active and standby units.  
The last [PR](https://github.com/canonical/bind-operator/pull/38) was about making sure that we have one active unit at almost all times, here we use that information to configure bind so that it is a primary DNS server on the active unit and a secondary on the standbys.

The different configurations for those are located in `src/constants.py` and applied using the `bind.update_zonefiles_and_reload()` function (which is really the core of the `bind` module in this charm.  

Some adjustments needed to be made because we're using the zone-transfer mechanism of the DNS protocol. This transfer is only done to a set of allowed IPs for security reasons. So we need to make sure to update that list of IPs as units in the deployment come and go. That's why we update the configuration on the peer `relation-departed`, `relation-joined` events and we check if we need to do it in the custom `reload-bind` event. 

A `topology` class was added in `src/models.py` to store and pass the network topology information around. It stores the IPs of the units deployed, which one is active, which one is a standby, what our current IP is.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
