### PR TITLE
Simplify get_conflicts() function

### DIFF
--- a/src/dns_data.py
+++ b/src/dns_data.py
@@ -147,24 +147,14 @@ def get_conflicts(zones: list[models.Zone]) -> tuple[set[models.DnsEntry], set[m
     Returns:
         A tuple containing the non-conflicting and conflicting entries
     """
-    entries = [e for z in zones for e in z.entries]
-    nonconflicting_entries: set[models.DnsEntry] = set()
+    entries: set[models.DnsEntry] = {e for z in zones for e in z.entries}
     conflicting_entries: set[models.DnsEntry] = set()
-    while entries:
-        entry = entries.pop()
-        found_conflict = False
-        if entry in conflicting_entries:
-            continue
+    for entry in entries:
         for e in entries:
             if entry.conflicts(e) and entry != e:
-                found_conflict = True
                 conflicting_entries.add(entry)
-                conflicting_entries.add(e)
 
-        if not found_conflict:
-            nonconflicting_entries.add(entry)
-
-    return (nonconflicting_entries, conflicting_entries)
+    return (entries - conflicting_entries, conflicting_entries)
 
 
 def dns_record_relations_data_to_zones(


### PR DESCRIPTION
### Overview

This drastically simplifies the `get_conflicts()` function at the expense of performance. But performance is not expected to be an issue while having robust and maintainable code is.  
This change was proposed by @arturo-seijas.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
