### PR TITLE
Serialize last valid state for future change comparison

### DIFF
--- a/src/bind.py
+++ b/src/bind.py
@@ -3,7 +3,6 @@
 
 """Bind charm business logic."""
 
-import json
 import logging
 import os
 import pathlib
@@ -187,12 +186,8 @@ class BindService:
         with tempfile.TemporaryDirectory() as tempdir:
 
             # Write the serialized state to a json file for future comparison
-            to_dump = {
-                "topology": topology.model_dump(mode="json") if topology is not None else "",
-                "zones": [zone.model_dump(mode="json") for zone in zones],
-            }
             pathlib.Path(constants.DNS_CONFIG_DIR, "state.json").write_text(
-                json.dumps(to_dump),
+                dns_data.dump_state(zones, topology),
                 encoding="utf-8",
             )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,7 +4,6 @@
 
 """Charm for bind."""
 
-import json
 import logging
 import pathlib
 import subprocess  # nosec
@@ -79,7 +78,7 @@ class BindCharm(ops.CharmBase):
 
         # Load the last valid state
         try:
-            last_valid_state = json.loads(
+            last_valid_state = dns_data.load_state(
                 pathlib.Path(constants.DNS_CONFIG_DIR, "state.json").read_text(encoding="utf-8")
             )
         except FileNotFoundError:

--- a/src/constants.py
+++ b/src/constants.py
@@ -30,6 +30,7 @@ ZONE_RECORD_TEMPLATE = "{host_label} {record_class} {record_type} {record_data}\
 NAMED_CONF_PRIMARY_ZONE_DEF_TEMPLATE = (
     'zone "{name}" IN {{ '
     'type primary; file "{absolute_path}"; allow-update {{ none; }}; '
+    "also-notify {{ {zone_transfer_ips} }}; "
     "allow-transfer {{ {zone_transfer_ips} }}; }};\n"
 )
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -19,7 +19,7 @@ $TTL 600
 status IN TXT "ok"
 """
 
-ZONE_HEADER_TEMPLATE = """$ORIGIN {zone}.; HASH:{hash}
+ZONE_HEADER_TEMPLATE = """$ORIGIN {zone}.
 $TTL 600
 @ IN SOA {zone}. mail.{zone}. ( {serial} 1d 1h 1h 10m )
 @ IN NS localhost.

--- a/src/dns_data.py
+++ b/src/dns_data.py
@@ -72,14 +72,14 @@ def has_changed(
     """
     zones = dns_record_relations_data_to_zones(relation_data)
 
-    if "zones" not in last_valid_state or last_valid_state["zones"] != zones:
+    # We assume "zones" and "topology" keys exist in last_valid_state
+    # As it was created from load_state()
+
+    if zones != last_valid_state["zones"]:
         return True
 
-    if topology is not None and "topology" in last_valid_state:
-        if last_valid_state["topology"] is None and topology is not None:
-            return True
-        if last_valid_state["topology"] is not None and topology != last_valid_state["topology"]:
-            return True
+    if topology != last_valid_state["topology"]:
+        return True
 
     return False
 

--- a/src/dns_data.py
+++ b/src/dns_data.py
@@ -72,17 +72,14 @@ def has_changed(
     """
     zones = dns_record_relations_data_to_zones(relation_data)
 
-    if "zones" not in last_valid_state or {
-        models.Zone(**z) for z in last_valid_state["zones"]
-    } != set(zones):
+    if "zones" not in last_valid_state or last_valid_state["zones"] != zones:
         return True
 
-    if (
-        topology is not None
-        and "topology" in last_valid_state
-        and topology != models.Topology(**last_valid_state["topology"])
-    ):
-        return True
+    if topology is not None and "topology" in last_valid_state:
+        if last_valid_state["topology"] is None and topology is not None:
+            return True
+        if last_valid_state["topology"] is not None and topology != last_valid_state["topology"]:
+            return True
 
     return False
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -178,6 +178,7 @@ async def generate_anycharm_relation(
     await ops_test.model.add_relation(f"{any_charm.name}", f"{app.name}")
     await ops_test.model.wait_for_idle(apps=[any_charm.name])
     await change_anycharm_relation(ops_test, any_charm.units[0], dns_entries)
+    await ops_test.model.wait_for_idle(apps=[any_charm.name])
 
 
 async def change_anycharm_relation(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -208,6 +208,7 @@ async def change_anycharm_relation(
         f"JUJU_UNIT_NAME={anyapp_unit.name} ./dispatch"
     )
     await run_on_unit(ops_test, anyapp_unit.name, cmd)
+    await ops_test.model.wait_for_idle()
 
 
 async def dig_query(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -109,11 +109,11 @@ async def push_to_unit(
     temp_filename_on_workload = _generate_random_filename()
     # unit does have scp_to
     await unit.scp_to(source=temp_path, destination=temp_filename_on_workload)  # type: ignore
-    mv_cmd = f"mv /home/ubuntu/{temp_filename_on_workload} {destination}"
+    mv_cmd = f"sudo mv -f /home/ubuntu/{temp_filename_on_workload} {destination}"
     await run_on_unit(ops_test, unit.name, mv_cmd)
-    chown_cmd = f"chown {user}:{group} {destination}"
+    chown_cmd = f"sudo chown {user}:{group} {destination}"
     await run_on_unit(ops_test, unit.name, chown_cmd)
-    chmod_cmd = f"chmod {mode} {destination}"
+    chmod_cmd = f"sudo chmod {mode} {destination}"
     await run_on_unit(ops_test, unit.name, chmod_cmd)
 
 
@@ -161,10 +161,6 @@ async def generate_anycharm_relation(
     any_charm_src_overwrite = {
         "any_charm.py": any_charm_content,
         "dns_record.py": dns_record_content,
-        # It's okay to write to /tmp for these tests, so # nosec is used
-        "/tmp/dns_entries.json": json.dumps(
-            [e.model_dump(mode="json") for e in dns_entries]
-        ),  # nosec
     }
 
     # We deploy https://charmhub.io/any-charm and inject the any_charm.py behavior
@@ -180,6 +176,37 @@ async def generate_anycharm_relation(
         },
     )
     await ops_test.model.add_relation(f"{any_charm.name}", f"{app.name}")
+    await ops_test.model.wait_for_idle(apps=[any_charm.name])
+    await change_anycharm_relation(ops_test, any_charm.units[0], dns_entries)
+
+
+async def change_anycharm_relation(
+    ops_test: OpsTest,
+    anyapp_unit: ops.model.Unit,
+    dns_entries: list[models.DnsEntry],
+):
+    """Change the relation of a anyapp_unit with the bind operator.
+
+    Args:
+        ops_test: The ops test framework instance
+        anyapp_unit: anyapp unit who's relation will change
+        dns_entries: List of DNS entries for any-charm
+    """
+    await push_to_unit(
+        ops_test,
+        anyapp_unit,
+        json.dumps([e.model_dump(mode="json") for e in dns_entries]),
+        "/srv/dns_entries.json",
+    )
+
+    # fire reload-data event
+    assert ops_test.model
+    cmd = (
+        "JUJU_DISPATCH_PATH=hooks/reload-data "
+        f"JUJU_MODEL_NAME={ops_test.model.name} "
+        f"JUJU_UNIT_NAME={anyapp_unit.name} ./dispatch"
+    )
+    await run_on_unit(ops_test, anyapp_unit.name, cmd)
 
 
 async def dig_query(
@@ -273,3 +300,14 @@ async def check_if_active_unit_exists(app: ops.model.Application, ops_test: OpsT
     if status != '"ok"':
         return False
     return True
+
+
+async def force_reload_bind(ops_test: OpsTest, unit: ops.model.Unit):
+    """Force reload bind.
+
+    Args:
+        ops_test: The ops test framework instance
+        unit: the bind unit to force reload
+    """
+    restart_cmd = f"sudo snap restart --reload {constants.DNS_SNAP_NAME}"
+    await run_on_unit(ops_test, unit.name, restart_cmd)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -248,15 +248,11 @@ async def test_dns_record_relation(
 
     await model.wait_for_idle()
 
-    # Force reload bind
-    restart_cmd = f"sudo snap restart --reload {constants.DNS_SNAP_NAME}"
-    # Application actually does have units
-    unit = app.units[0]  # type: ignore
-    await tests.integration.helpers.run_on_unit(ops_test, unit.name, restart_cmd)
+    await tests.integration.helpers.force_reload_bind(ops_test, app.units[0])  # type: ignore
     await model.wait_for_idle()
 
     # Test the status of the bind-operator instance
-    assert unit.workload_status == status.name
+    assert app.units[0].workload_status == status.name  # type: ignore
 
     # Test if the records give the correct results
     # Do that only if we have an active status
@@ -266,7 +262,7 @@ async def test_dns_record_relation(
 
                 result = await tests.integration.helpers.dig_query(
                     ops_test,
-                    unit,
+                    app.units[0],  # type: ignore
                     f"@127.0.0.1 {entry.host_label}.{entry.domain} {entry.record_type} +short",
                     retry=True,
                     wait=5,

--- a/tests/integration/test_multi_units.py
+++ b/tests/integration/test_multi_units.py
@@ -43,7 +43,7 @@ async def test_multi_units(
             models.DnsEntry(
                 domain="dns.test",
                 host_label="admin",
-                ttl=600,
+                ttl=5,
                 record_class="IN",
                 record_type="A",
                 record_data="42.42.42.42",
@@ -100,7 +100,7 @@ async def test_multi_units(
             models.DnsEntry(
                 domain="dns.test",
                 host_label="admin",
-                ttl=600,
+                ttl=5,
                 record_class="IN",
                 record_type="A",
                 record_data="43.43.43.43",

--- a/tests/integration/test_multi_units.py
+++ b/tests/integration/test_multi_units.py
@@ -52,27 +52,22 @@ async def test_multi_units(
     )
     await model.wait_for_idle()
 
-    # Define the test that we're going to make multiple times
-    async def assert_has_dns_record(unit: ops.model.Unit):
-        """Test if the unit exposes the target DNS record.
-
-        Args:
-            unit: Unit to test
-        """
-        result = await tests.integration.helpers.dig_query(
-            ops_test,
-            unit,
-            "@127.0.0.1 admin.dns.test A +short",
-            retry=True,
-            wait=5,
-        )
-        assert result == "42.42.42.42", f"Issue with {unit.name}"
-
     # Start by testing that everything is fine
     assert await tests.integration.helpers.check_if_active_unit_exists(app, ops_test)
     # Application actually does have units
     for unit in app.units:  # type: ignore
-        await assert_has_dns_record(unit)
+        await tests.integration.helpers.force_reload_bind(ops_test, unit)
+        await model.wait_for_idle()
+        assert (
+            await tests.integration.helpers.dig_query(
+                ops_test,
+                unit,
+                "@127.0.0.1 admin.dns.test A +short",
+                retry=True,
+                wait=5,
+            )
+            == "42.42.42.42"
+        ), "Initial test failed"
 
     # add a unit and verify that everything goes well
     assert ops_test.model is not None
@@ -82,7 +77,51 @@ async def test_multi_units(
     assert await tests.integration.helpers.check_if_active_unit_exists(app, ops_test)
     # Application actually does have units
     for unit in app.units:  # type: ignore
-        await assert_has_dns_record(unit)
+        await tests.integration.helpers.force_reload_bind(ops_test, unit)
+        await model.wait_for_idle()
+        assert (
+            await tests.integration.helpers.dig_query(
+                ops_test,
+                unit,
+                "@127.0.0.1 admin.dns.test A +short",
+                retry=True,
+                wait=5,
+            )
+            == "42.42.42.42"
+        ), "Failed after adding one unit"
+
+    # Change the domain requested by any-app
+    anyapp_name = "anyapp-t1"
+    anyapp = model.applications[anyapp_name]
+    await tests.integration.helpers.change_anycharm_relation(
+        ops_test,
+        anyapp.units[0],
+        [
+            models.DnsEntry(
+                domain="dns.test",
+                host_label="admin",
+                ttl=600,
+                record_class="IN",
+                record_type="A",
+                record_data="43.43.43.43",
+            ),
+        ],
+    )
+    await model.wait_for_idle()
+    # Application actually does have units
+    for unit in app.units:  # type: ignore
+        await tests.integration.helpers.force_reload_bind(ops_test, unit)
+        await model.wait_for_idle()
+        assert (
+            await tests.integration.helpers.dig_query(
+                ops_test,
+                unit,
+                "@127.0.0.1 admin.dns.test A +short",
+                retry=True,
+                wait=5,
+            )
+            == "43.43.43.43"
+        ), "Failed after changing DNS request"
 
     # remove the active unit and check that we're still all right
     active_unit = await tests.integration.helpers.get_active_unit(app, ops_test)
@@ -95,4 +134,15 @@ async def test_multi_units(
     assert await tests.integration.helpers.check_if_active_unit_exists(app, ops_test)
     # Application actually does have units
     for unit in app.units:  # type: ignore
-        await assert_has_dns_record(unit)
+        await tests.integration.helpers.force_reload_bind(ops_test, unit)
+        await model.wait_for_idle()
+        assert (
+            await tests.integration.helpers.dig_query(
+                ops_test,
+                unit,
+                "@127.0.0.1 admin.dns.test A +short",
+                retry=True,
+                wait=5,
+            )
+            == "43.43.43.43"
+        ), "Failed after removing one bind unit"

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -58,6 +58,21 @@ RECORDS = {
     ),
 }
 
+TOPOLOGIES = {
+    "3_units_current_not_active": {
+        "units_ip": ["1.1.1.1", "2.2.2.2", "3.3.3.3"],
+        "active_unit_ip": "1.1.1.1",
+        "standby_units_ip": ["2.2.2.2", "3.3.3.3"],
+        "current_unit_ip": "2.2.2.2",
+    },
+    "4_units_current_not_active": {
+        "units_ip": ["1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4"],
+        "active_unit_ip": "1.1.1.1",
+        "standby_units_ip": ["2.2.2.2", "3.3.3.3", "4.4.4.4"],
+        "current_unit_ip": "2.2.2.2",
+    },
+}
+
 
 def dns_record_requirers_data_from_integration_datasets(
     integration_datasets,

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helper functions for the unit tests."""
+
+# Ignore duplicate code from the helpers (they can be in the charm also)
+# pylint: disable=duplicate-code
+
+import uuid
+
+from charms.bind.v0 import dns_record
+
+import models
+
+SERVICE_ACCOUNT = "fakeserviceaccount"
+
+RECORDS = {
+    "admin.dns.test_42": models.DnsEntry(
+        domain="dns.test",
+        host_label="admin",
+        ttl=600,
+        record_class="IN",
+        record_type="A",
+        record_data="1.1.1.42",
+    ),
+    "admin.dns.test_41": models.DnsEntry(
+        domain="dns.test",
+        host_label="admin",
+        ttl=600,
+        record_class="IN",
+        record_type="A",
+        record_data="1.1.1.41",
+    ),
+    "admin.dns2.test_43": models.DnsEntry(
+        domain="dns2.test",
+        host_label="admin",
+        ttl=600,
+        record_class="IN",
+        record_type="A",
+        record_data="1.1.1.43",
+    ),
+    "admin.dns2.test_41": models.DnsEntry(
+        domain="dns2.test",
+        host_label="admin",
+        ttl=600,
+        record_class="IN",
+        record_type="A",
+        record_data="1.1.1.41",
+    ),
+    "admin2.dns.test_40": models.DnsEntry(
+        domain="dns.test",
+        host_label="admin2",
+        ttl=600,
+        record_class="IN",
+        record_type="A",
+        record_data="1.1.1.40",
+    ),
+}
+
+
+def dns_record_requirers_data_from_integration_datasets(
+    integration_datasets,
+) -> list[dns_record.DNSRecordRequirerData]:
+    """Create a list of DnsRecordRequirerData given integration_datasets.
+
+    Args:
+        integration_datasets: the datasets representing integration data
+
+    Returns:
+        A list of DNSRecordRequirerData.
+    """
+    record_requirers_data = []
+    for requirer in integration_datasets:
+        requirer_entries = [
+            dns_record.RequirerEntry(
+                domain=e.domain,
+                host_label=e.host_label,
+                ttl=e.ttl,
+                record_class=e.record_class,
+                record_type=e.record_type,
+                record_data=e.record_data,
+                uuid=uuid.uuid4(),
+            )
+            for e in requirer
+        ]
+        record_requirer_data = dns_record.DNSRecordRequirerData(
+            dns_entries=requirer_entries,
+            service_account=SERVICE_ACCOUNT,
+        )
+        record_requirers_data.append(record_requirer_data)
+
+    return record_requirers_data

--- a/tests/unit/test_dns_data.py
+++ b/tests/unit/test_dns_data.py
@@ -3,13 +3,12 @@
 
 """Unit tests for the dns_data module."""
 
-import uuid
+import json
 
 import pytest
-from charms.bind.v0 import dns_record
 
 import dns_data
-import models
+import tests.unit.helpers
 
 
 @pytest.mark.parametrize(
@@ -18,40 +17,12 @@ import models
         (
             [
                 [
-                    models.DnsEntry(
-                        domain="dns.test",
-                        host_label="admin",
-                        ttl=600,
-                        record_class="IN",
-                        record_type="A",
-                        record_data="42.42.42.42",
-                    ),
-                    models.DnsEntry(
-                        domain="dns.test",
-                        host_label="admin",
-                        ttl=600,
-                        record_class="IN",
-                        record_type="A",
-                        record_data="42.42.42.42",
-                    ),
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
                 ],
                 [
-                    models.DnsEntry(
-                        domain="dns.test",
-                        host_label="admin",
-                        ttl=600,
-                        record_class="IN",
-                        record_type="A",
-                        record_data="42.42.42.42",
-                    ),
-                    models.DnsEntry(
-                        domain="dns2.test",
-                        host_label="admin",
-                        ttl=600,
-                        record_class="IN",
-                        record_type="A",
-                        record_data="42.42.42.43",
-                    ),
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
+                    tests.unit.helpers.RECORDS["admin.dns2.test_43"],
                 ],
             ],
             {"dns.test", "dns2.test"},
@@ -61,30 +32,9 @@ import models
         (
             [
                 [
-                    models.DnsEntry(
-                        domain="dns.test",
-                        host_label="admin",
-                        ttl=600,
-                        record_class="IN",
-                        record_type="A",
-                        record_data="42.42.42.42",
-                    ),
-                    models.DnsEntry(
-                        domain="dns2.test",
-                        host_label="admin",
-                        ttl=600,
-                        record_class="IN",
-                        record_type="A",
-                        record_data="41.41.41.41",
-                    ),
-                    models.DnsEntry(
-                        domain="dns.test",
-                        host_label="admin2",
-                        ttl=600,
-                        record_class="IN",
-                        record_type="A",
-                        record_data="40.40.40.40",
-                    ),
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
+                    tests.unit.helpers.RECORDS["admin.dns2.test_41"],
+                    tests.unit.helpers.RECORDS["admin2.dns.test_40"],
                 ],
             ],
             {"dns.test", "dns2.test"},
@@ -94,22 +44,8 @@ import models
         (
             [
                 [
-                    models.DnsEntry(
-                        domain="dns.test",
-                        host_label="admin",
-                        ttl=600,
-                        record_class="IN",
-                        record_type="A",
-                        record_data="42.42.42.42",
-                    ),
-                    models.DnsEntry(
-                        domain="dns.test",
-                        host_label="admin",
-                        ttl=600,
-                        record_class="IN",
-                        record_type="A",
-                        record_data="41.41.41.41",
-                    ),
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
+                    tests.unit.helpers.RECORDS["admin.dns.test_41"],
                 ],
             ],
             {"dns.test"},
@@ -129,29 +65,14 @@ def test_get_conflicts(integration_datasets, zones_name, nonconflicting, conflic
     act: generate conflicting sets of DnsEntries
     assert: that the generate set is what we expected
     """
-    record_requirers_data = []
-    for requirer in integration_datasets:
-        requirer_entries = [
-            dns_record.RequirerEntry(
-                domain=e.domain,
-                host_label=e.host_label,
-                ttl=e.ttl,
-                record_class=e.record_class,
-                record_type=e.record_type,
-                record_data=e.record_data,
-                uuid=uuid.uuid4(),
-            )
-            for e in requirer
-        ]
-        record_requirer_data = dns_record.DNSRecordRequirerData(
-            dns_entries=requirer_entries,
-            service_account="fakeserviceaccount",
-        )
-        record_requirers_data.append(record_requirer_data)
+    record_requirers_data = tests.unit.helpers.dns_record_requirers_data_from_integration_datasets(
+        integration_datasets
+    )
 
     zones = dns_data.dns_record_relations_data_to_zones(  # pylint: disable=protected-access
         [(record_requirer_data, None) for record_requirer_data in record_requirers_data]
     )
+
     assert zones_name == {zone.domain for zone in zones}
 
     output = dns_data.get_conflicts(zones)  # pylint: disable=protected-access
@@ -160,95 +81,91 @@ def test_get_conflicts(integration_datasets, zones_name, nonconflicting, conflic
 
 
 @pytest.mark.parametrize(
-    "zonefile_content, metadata, error",
+    "integration_datasets_before, integration_datasets_after, expected_has_changed",
     (
-        ("", {}, dns_data.EmptyZoneFileMetadataError),
-        ("sometext; someothertext", {}, dns_data.EmptyZoneFileMetadataError),
-        ("$ORIGIN test.dns.test.; HASH:1234", {"HASH": "1234"}, None),
         (
-            "$ORIGIN test.dns.test.; HASH:1234\n$ORIGIN test2.dns.test.; PLOP:plop",
-            {"HASH": "1234", "PLOP": "plop"},
-            None,
+            [
+                [
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
+                ],
+                [
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
+                    tests.unit.helpers.RECORDS["admin.dns2.test_43"],
+                ],
+            ],
+            [
+                [
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
+                ],
+                [
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
+                    tests.unit.helpers.RECORDS["admin.dns2.test_43"],
+                ],
+            ],
+            False,
         ),
         (
-            "$ORIGIN test.dns.test.; HASH:1234 HASH:4567",
-            {},
-            dns_data.DuplicateMetadataEntryError,
+            [
+                [
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
+                    tests.unit.helpers.RECORDS["admin.dns2.test_43"],
+                ],
+            ],
+            [
+                [
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
+                ],
+            ],
+            True,
         ),
         (
-            "$ORIGIN test.dns.test.; HASH:1234\n$ORIGIN test2.dns.test.; HASH:4567",
-            {},
-            dns_data.DuplicateMetadataEntryError,
-        ),
-        ("$ORIGIN test.dns.test.; HASH::", None, dns_data.InvalidZoneFileMetadataError),
-        ("$ORIGIN test.dns.test.;    ", {"HASH": "1234"}, dns_data.EmptyZoneFileMetadataError),
-        (
-            "\n\nsometext\n\n$ORIGIN test.dns.test.; HASH:1234 PLOP:plop\nsomeothertext",
-            {"HASH": "1234", "PLOP": "plop"},
-            None,
+            [
+                [
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
+                ],
+            ],
+            [
+                [
+                    tests.unit.helpers.RECORDS["admin.dns.test_42"],
+                    tests.unit.helpers.RECORDS["admin.dns2.test_43"],
+                ],
+            ],
+            True,
         ),
     ),
+    ids=(
+        "Removed duplicate entry",
+        "Removed entry",
+        "Added entry",
+    ),
 )
-def test_get_zonefile_metadata(zonefile_content: str, metadata: dict[str, str], error):
+def test_has_changed(
+    integration_datasets_before, integration_datasets_after, expected_has_changed
+):
     """
-    arrange: nothing
-    act: get the metadata from the zonefile_content
-    assert: the correct metadata should be found or the correct exception raised
+    arrange: prepare some integration datasets
+    act: Serialize the 'before' dataset
+    assert: check if the comparison of the before dataset with the after is what we expected
     """
-    if error is not None:
-        with pytest.raises(error):
-            dns_data._get_zonefile_metadata(zonefile_content)  # pylint: disable=protected-access
-    else:
-        assert metadata == dns_data._get_zonefile_metadata(  # pylint: disable=protected-access
-            zonefile_content
+    record_requirers_data_before = (
+        tests.unit.helpers.dns_record_requirers_data_from_integration_datasets(
+            integration_datasets_before
         )
-
-
-@pytest.mark.parametrize(
-    "named_conf_content, wanted",
-    (
-        (
-            # pylint: disable=line-too-long
-            """
-            include "/some/path/zones.rfc1918";
-            zone "service.test" IN { type primary; file "/some/path/db.service.test"; allow-update { none; }; allow-transfer {  }; };
-            """,
-            [],
-        ),
-        (
-            # pylint: disable=line-too-long
-            """
-            include "/some/path/zones.rfc1918";
-            zone "service.test" IN { type primary; file "/some/path/db.service.test"; allow-update { none; }; allow-transfer { 42.42.42.42; }; };
-            """,
-            ["42.42.42.42"],
-        ),
-        (
-            # pylint: disable=line-too-long
-            """
-            include "/some/path/zones.rfc1918";
-            zone "service.test" IN { type primary; file "/some/path/db.service.test"; allow-update { none; }; allow-transfer { 42.42.42.42; 42.42.42.43; }; };
-            """,
-            ["42.42.42.42", "42.42.42.43"],
-        ),
-        (
-            # pylint: disable=line-too-long
-            """
-            include "/some/path/zones.rfc1918";
-            zone "service.test" IN { type primary; file "/some/path/db.service.test"; allow-update { none; }; allow-transfer { 42.42.42.42; }; };
-            zone "service2.test" IN { type primary; file "/some/path/db.service.test"; allow-update { none; }; allow-transfer { 42.42.42.43; }; };
-            """,
-            ["42.42.42.42"],
-        ),
-    ),
-)
-def test_get_secondaries_ip_from_conf(named_conf_content: str, wanted: list[str]):
-    """
-    arrange: nothing
-    act: get the IPs from named_conf_content
-    assert: the correct IPs should be found
-    """
-    result = dns_data._get_secondaries_ip_from_conf(  # pylint: disable=protected-access
-        named_conf_content
     )
-    assert wanted == result
+    zones = dns_data.dns_record_relations_data_to_zones(
+        [(record_requirer_data, None) for record_requirer_data in record_requirers_data_before]
+    )
+    serialized_zones = json.dumps({"topology": "", "zones":[z.model_dump(mode="json") for z in zones]})
+
+    record_requirers_data_after = (
+        tests.unit.helpers.dns_record_requirers_data_from_integration_datasets(
+            integration_datasets_after
+        )
+    )
+
+    assert expected_has_changed == dns_data.has_changed(
+        [(record_requirer_data, None) for record_requirer_data in record_requirers_data_after],
+        None,
+        json.loads(serialized_zones),
+    )

--- a/tests/unit/test_dns_data.py
+++ b/tests/unit/test_dns_data.py
@@ -3,8 +3,6 @@
 
 """Unit tests for the dns_data module."""
 
-import json
-
 import pytest
 
 import dns_data


### PR DESCRIPTION
### Overview

The zone-transfer mechanism doesn't copy the "ORIGIN" line from the zone file to the secondaries and it was used to store the hash of the zone to check for changes before reloading bind.  
Adding to that, parsing the config files to get the network topology of the last valid state was error prone and we also couldn't detect the removal of a zone.

We now serialize the last valid state (composed of the network topology and the zones) into a json file and load it to check for changes before recomputing the configuration and reloading bind.  
This ends up removing the code related to parsing the metadata and IPs from bind configuration files.

The change in our any-charm usage was made to allow for after deployment changes in the requested dns records (the dns entries file cannot be defined during deployment: it gets overriden by any-charm while handling later events).

I also had to add `also-notify` to the zone config to effectively propagate the zone change event and initiate the zone transfer. An alternative would be to use the `NS` record but I decided against it in the interest of simplicity for the time being.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
