### PR TITLE
Add open_port operations at init

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -63,6 +63,9 @@ class BindCharm(ops.CharmBase):
         self.framework.observe(
             self.on[constants.PEER].relation_joined, self._on_peer_relation_joined
         )
+        self.unit.open_port("tcp", 8080)  # ACL API
+        self.unit.open_port("tcp", 53)  # Bind DNS
+        self.unit.open_port("udp", 53)  # Bind DNS
 
     def _on_reload_bind(self, _: events.ReloadBindEvent) -> None:
         """Handle periodic reload bind event.


### PR DESCRIPTION
### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
