### PR TITLE
Remove optional charmed-bind snap resource file

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -31,8 +31,3 @@ provides:
 peers:
   bind-peers:
     interface: bind-instance
-resources:
-  charmed-bind-snap:
-    type: file
-    filename: charmed-bind.snap
-    description: (local) charmed-bind snap file for debugging purposes

--- a/src/bind.py
+++ b/src/bind.py
@@ -106,17 +106,15 @@ class BindService:
             logger.error(error_msg)
             raise StopError(error_msg) from e
 
-    def setup(self, unit_name: str, snap_path: str | None) -> None:
+    def setup(self, unit_name: str) -> None:
         """Prepare the machine.
 
         Args:
             unit_name: The name of the current unit
-            snap_path: The path to the snap to install, can be blank.
         """
         self._install_snap_package(
             snap_name=constants.DNS_SNAP_NAME,
             snap_channel=constants.SNAP_PACKAGES[constants.DNS_SNAP_NAME]["channel"],
-            snap_path=snap_path,
         )
         self._install_bind_reload_service(unit_name)
         # We need to put the service zone in place so we call
@@ -231,37 +229,24 @@ class BindService:
         logger.debug("Update and reload duration (ms): %s", (time.time_ns() - start_time) / 1e6)
 
     def _install_snap_package(
-        self, snap_name: str, snap_channel: str, snap_path: str | None, refresh: bool = False
+        self, snap_name: str, snap_channel: str, refresh: bool = False
     ) -> None:
         """Installs snap package.
 
         Args:
             snap_name: the snap package to install
             snap_channel: the snap package channel
-            snap_path: The path to the snap to install, can be blank.
             refresh: whether to refresh the snap if it's already present.
 
         Raises:
             InstallError: when encountering a SnapError or a SnapNotFoundError
         """
         try:
-            # If a snap resource was not given, install the snap as published on snapcraft
-            if snap_path is None or snap_path == "":
-                snap_cache = snap.SnapCache()
-                snap_package = snap_cache[snap_name]
+            snap_cache = snap.SnapCache()
+            snap_package = snap_cache[snap_name]
 
-                if not snap_package.present or refresh:
-                    snap_package.ensure(snap.SnapState.Latest, channel=snap_channel)
-            else:
-                # Installing the charm via subprocess.
-                # Calling subprocess here is not a security issue.
-                logger.info(
-                    "Installing from custom charmed-bind snap located: %s",
-                    snap_path,
-                )
-                subprocess.check_output(
-                    ["sudo", "snap", "install", snap_path, "--dangerous"]
-                )  # nosec
+            if not snap_package.present or refresh:
+                snap_package.ensure(snap.SnapState.Latest, channel=snap_channel)
         except (snap.SnapError, snap.SnapNotFoundError, subprocess.CalledProcessError) as e:
             error_msg = f"An exception occurred when installing {snap_name}. Reason: {e}"
             logger.exception(error_msg)

--- a/src/charm.py
+++ b/src/charm.py
@@ -66,16 +66,6 @@ class BindCharm(ops.CharmBase):
         self.unit.open_port("tcp", 53)  # Bind DNS
         self.unit.open_port("udp", 53)  # Bind DNS
 
-        # Record if the `charmed-bind-snap` resource is defined.
-        # Using this can be useful when debugging locally
-        # More information about resources:
-        # https://juju.is/docs/sdk/resources#heading--add-a-resource-to-a-charm
-        self.snap_path: str | None = None
-        try:
-            self.snap_path = str(self.model.resources.fetch("charmed-bind-snap"))
-        except ops.ModelError as e:
-            logger.warning(e)
-
     def _on_reload_bind(self, _: events.ReloadBindEvent) -> None:
         """Handle periodic reload bind event.
 
@@ -156,7 +146,7 @@ class BindCharm(ops.CharmBase):
     def _on_install(self, _: ops.InstallEvent) -> None:
         """Handle install."""
         self.unit.status = ops.MaintenanceStatus("Preparing bind")
-        self.bind.setup(self.unit.name, self.snap_path)
+        self.bind.setup(self.unit.name)
 
     def _on_start(self, _: ops.StartEvent) -> None:
         """Handle start."""
@@ -169,7 +159,7 @@ class BindCharm(ops.CharmBase):
     def _on_upgrade_charm(self, _: ops.UpgradeCharmEvent) -> None:
         """Handle upgrade-charm."""
         self.unit.status = ops.MaintenanceStatus("Upgrading dependencies")
-        self.bind.setup(self.unit.name, self.snap_path)
+        self.bind.setup(self.unit.name)
 
     def _on_leader_elected(self, _: ops.LeaderElectedEvent) -> None:
         """Handle leader-elected event."""


### PR DESCRIPTION
Charmhub is not allowing optional resources and we don't strictly need this for now.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
