### PR TITLE
Add Arturo to the codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @nrobinaubertin @amandahla @gregory-schiano
+*       @nrobinaubertin @amandahla @gregory-schiano @arturo-seijas


### PR DESCRIPTION
I'm adding @arturo-seijas to the `CODEOWNERS` file since Gregory cannot/should not review all the trivial PRs