### PR TITLE
Disable jubilant logging for juju.deploy, juju.config and juju.exec

### DIFF
--- a/bind-operator/tests/integration/conftest.py
+++ b/bind-operator/tests/integration/conftest.py
@@ -65,7 +65,9 @@ async def app_fixture(
         yield model.applications[app_name]
         return
 
-    application = await model.deploy(f"./{charm_file}", application_name=app_name, resources={})
+    application = await model.deploy(
+        f"./{charm_file}", application_name=app_name, resources={}, log=False
+    )
 
     await model.wait_for_idle(apps=[application.name], status="active")
 

--- a/bind-operator/tests/integration/helpers.py
+++ b/bind-operator/tests/integration/helpers.py
@@ -180,7 +180,7 @@ async def generate_anycharm_relation(
     }
     if machine is not None:
         args["to"] = machine
-    any_charm = await ops_test.model.deploy("any-charm", storage=None, **args)
+    any_charm = await ops_test.model.deploy("any-charm", storage=None, **args, log=False)
     await ops_test.model.wait_for_idle(apps=[any_charm.name])
     await ops_test.model.add_relation(
         f"{any_charm.name}:require-dns-record", f"{app.name}:dns-record"

--- a/dns-policy-operator/tests/integration/conftest.py
+++ b/dns-policy-operator/tests/integration/conftest.py
@@ -64,11 +64,12 @@ async def dns_policy_fixture(
             application_name=dns_policy_name,
             resources=resources,
             num_units=0,  # subordinate charm
+            log=False,
         )
     else:
         charm = await ops_test.build_charm(".")
         application = await model.deploy(
-            charm, application_name=dns_policy_name, resources=resources
+            charm, application_name=dns_policy_name, resources=resources, log=False
         )
 
     yield application
@@ -81,9 +82,7 @@ async def postgresql_fixture(
 ):
     """Deploy the postgresql charm."""
     postgres_app = await model.deploy(
-        "postgresql",
-        channel="14/stable",
-        config={"profile": "testing"},
+        "postgresql", channel="14/stable", config={"profile": "testing"}, log=False
     )
     async with ops_test.fast_forward():
         await model.wait_for_idle(apps=[postgres_app.name], status="active")
@@ -108,11 +107,13 @@ async def bind_fixture(
 
     if charm := pytestconfig.getoption("--bind-charm-file"):
         application = await model.deploy(
-            f"../bind-operator/{charm}", application_name=bind_name, resources=resources
+            f"../bind-operator/{charm}", application_name=bind_name, resources=resources, log=False
         )
     else:
         charm = await ops_test.build_charm("../bind-operator/")
-        application = await model.deploy(charm, application_name=bind_name, resources=resources)
+        application = await model.deploy(
+            charm, application_name=bind_name, resources=resources, log=False
+        )
 
     await model.wait_for_idle(apps=[application.name], status="active")
 

--- a/dns-resolver-operator/tests/integration/conftest.py
+++ b/dns-resolver-operator/tests/integration/conftest.py
@@ -163,12 +163,7 @@ async def dns_resolver_fixture(
     if use_existing:
         return
 
-    juju.deploy(
-        dns_resolver_charm_file,
-        dns_resolver_name,
-        resources={},
-        num_units=1,
-    )
+    juju.deploy(dns_resolver_charm_file, dns_resolver_name, resources={}, num_units=1, log=False)
 
 
 @pytest_asyncio.fixture(scope="module", name="bind")
@@ -183,7 +178,7 @@ async def bind_fixture(
     if use_existing:
         return
 
-    juju.deploy(bind_charm_file, bind_name, resources={})
+    juju.deploy(bind_charm_file, bind_name, resources={}, log=False)
     juju.wait(lambda status: jubilant.all_active(status, bind_name))
 
 

--- a/dns-secondary-operator/tests/integration/bind_fixtures.py
+++ b/dns-secondary-operator/tests/integration/bind_fixtures.py
@@ -60,5 +60,5 @@ async def bind_fixture(
     bind_name: str,
 ):
     """Deploy the charm."""
-    juju.deploy(bind_charm_file, bind_name, resources={})
+    juju.deploy(bind_charm_file, bind_name, resources={}, log=False)
     juju.wait(lambda status: jubilant.all_active(status, bind_name))

--- a/dns-secondary-operator/tests/integration/conftest.py
+++ b/dns-secondary-operator/tests/integration/conftest.py
@@ -69,7 +69,7 @@ def charm_file_fixture(metadata: dict[str, typing.Any], pytestconfig: pytest.Con
 @pytest.fixture(scope="module", name="app")
 def app_fixture(juju: jubilant.Juju, charm_file, app_name):
     """Deploy secondary charm."""
-    juju.deploy(charm=charm_file, app=app_name, resources={})
+    juju.deploy(charm=charm_file, app=app_name, resources={}, log=False)
     juju.wait(jubilant.all_agents_idle, timeout=600)
     juju.wait(jubilant.all_blocked)
     yield app_name  # run the test

--- a/tests/bind_fixtures.py
+++ b/tests/bind_fixtures.py
@@ -68,5 +68,5 @@ async def bind_fixture(
     if use_existing:
         return
 
-    juju.deploy(bind_charm_file, bind_name, resources={})
+    juju.deploy(bind_charm_file, bind_name, resources={}, log=False)
     juju.wait(lambda status: jubilant.all_active(status, bind_name))

--- a/tests/dns_integrator_fixtures.py
+++ b/tests/dns_integrator_fixtures.py
@@ -70,5 +70,5 @@ async def dns_integrator_fixture(
     if use_existing:
         return
 
-    juju.deploy(dns_integrator_charm_file, dns_integrator_name, resources={})
+    juju.deploy(dns_integrator_charm_file, dns_integrator_name, resources={}, log=False)
     juju.wait(lambda status: jubilant.all_blocked(status, dns_integrator_name))

--- a/tests/dns_policy_fixtures.py
+++ b/tests/dns_policy_fixtures.py
@@ -68,5 +68,5 @@ async def dns_policy_fixture(
     if use_existing:
         return
 
-    juju.deploy(dns_policy_charm_file, dns_policy_name, resources={})
+    juju.deploy(dns_policy_charm_file, dns_policy_name, resources={}, log=False)
     juju.wait(lambda status: jubilant.all_active(status, dns_policy_name))

--- a/tests/dns_resolver_fixtures.py
+++ b/tests/dns_resolver_fixtures.py
@@ -68,5 +68,5 @@ async def dns_resolver_fixture(
     if use_existing:
         return
 
-    juju.deploy(dns_resolver_charm_file, dns_resolver_name, resources={})
+    juju.deploy(dns_resolver_charm_file, dns_resolver_name, resources={}, log=False)
     juju.wait(lambda status: jubilant.all_blocked(status, dns_resolver_name))

--- a/tests/dns_secondary_fixtures.py
+++ b/tests/dns_secondary_fixtures.py
@@ -70,5 +70,5 @@ async def dns_secondary_fixture(
     if use_existing:
         return
 
-    juju.deploy(dns_secondary_charm_file, dns_secondary_name, resources={})
+    juju.deploy(dns_secondary_charm_file, dns_secondary_name, resources={}, log=False)
     juju.wait(lambda status: jubilant.all_blocked(status, dns_secondary_name))

--- a/tests/postgresql_fixtures.py
+++ b/tests/postgresql_fixtures.py
@@ -32,5 +32,11 @@ async def postgresql_fixture(
     if use_existing:
         return
 
-    juju.deploy("postgresql", postgresql_name, channel=postgresql_channel, resources={})
+    juju.deploy(
+        "postgresql",
+        postgresql_name,
+        channel=postgresql_channel,
+        resources={},
+        log=False,
+    )
     juju.wait(lambda status: jubilant.all_active(status, postgresql_name))

--- a/tests/test_charms.py
+++ b/tests/test_charms.py
@@ -174,6 +174,7 @@ async def test_active(
         {
             "requests": integrator_config,
         },
+        log=False,
     )
 
     # Waiting for 2mn as this is the maximum time for bind's config to update and propagate


### PR DESCRIPTION
Add log=False to all juju.deploy(), juju.config() and juju.exec() calls in integration tests.