### PR TITLE
chore(docs): add sitemap_filename configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,6 +191,8 @@ html_baseurl = f"https://canonical.com/juju/docs/dns-charms/{version}/"
 
 sitemap_url_scheme = '{link}'
 
+sitemap_filename = "doc-sitemap.xml"
+
 # Include `lastmod` dates in the sitemap:
 
 sitemap_show_lastmod = True


### PR DESCRIPTION
#### What this PR does

Adds `sitemap_filename` to `docs/conf.py`.

#### Why we need it

Aligns with recommended sitemap configuration according to https://documentation.ubuntu.com/rtd-proxy/how-to/migrate/#sitemaps

#### Validation

https://canonical-dns-charms--463.com.readthedocs.build/463/doc-sitemap.xml