### PR TITLE
chore: codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @nrobinaubertin @amandahla @gregory-schiano @DeeKay3 @srbouffard
+*       @nrobinaubertin @amandahla @gregory-schiano @DeeKay3 @srbouffard @canonical/platform-engineering-apac


### PR DESCRIPTION
Fixes the repolint 'codeowners' check: adds `@canonical/platform-engineering-apac` as an additional CODEOWNERS entry alongside the existing named individual owners.